### PR TITLE
Bug fix for gnome-terminal

### DIFF
--- a/src/fabric/executils.cpp
+++ b/src/fabric/executils.cpp
@@ -104,6 +104,7 @@ int runHostExecutable(const QString &exe, const QStringList &args, bool waitForF
 int runInExternalTerminal(const QString &cmd, const QStringList &args, const QString &wdir)
 {
     QString terminalExe;
+    QString terminalArg = "-e";
     QStringList extraTermArgs;
     auto sysInfo = SysInfo::get();
 
@@ -113,10 +114,12 @@ int runInExternalTerminal(const QString &cmd, const QStringList &args, const QSt
     }
     if (terminalExe.isEmpty()) {
         terminalExe = findHostExecutable("gnome-terminal");
+        terminalArg = "--"; // "-e" is deprecated in newer versions
         extraTermArgs.append("--hide-menubar");
     }
     if (terminalExe.isEmpty())
         terminalExe = findHostExecutable("xterm");
+
     if (terminalExe.isEmpty())
         terminalExe = findHostExecutable("x-terminal-emulator");
 
@@ -153,12 +156,12 @@ int runInExternalTerminal(const QString &cmd, const QStringList &args, const QSt
             fpsArgs << "--directory=" + wdir;
         fpsArgs << terminalExe;
 
-        const auto termArgs = QStringList() << "-e"
+        const auto termArgs = QStringList() << terminalArg
                                             << "flatpak enter " + sysInfo->sandboxAppId() + " sh -c " + shHelperFname;
         proc.start("flatpak-spawn", fpsArgs + extraTermArgs + termArgs);
     } else {
         // no sandbox, we can run the command directly
-        const auto termArgs = QStringList() << "-e"
+        const auto termArgs = QStringList() << terminalArg
                                             << "sh"
                                             << "-c" << shHelperFname;
         if (!wdir.isEmpty())


### PR DESCRIPTION
For newer gnome-terminal this does not work `gnome-terminal -e sh -c "..."`, it must be `gnome-terminal -- sh -c "..."`

```bash
$ gnome-terminal -e sh -c 'sleep 2; echo "bla"; sleep 2'
# Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
# Use “-- ” to terminate the options and put the command line to execute after it.
# Failed to parse arguments: Unknown option -c
```

From a quick search `gnome-terminal` supports `--` for a very long time so this should be backwards compatible :)

Additionally I added a `set -x` in the `installVirtualEnv()` function's script so that it is easier to debug where my the problems #29 are coming from 