### PR TITLE
python: Set language mode instead of text highlight

### DIFF
--- a/modules/pyscript/pyscriptmodule.cpp
+++ b/modules/pyscript/pyscriptmodule.cpp
@@ -76,7 +76,7 @@ public:
         m_scriptWindow->setWindowTitle(QStringLiteral("%1 - Editor").arg(name()));
 
         m_scriptView = pyDoc->createView(m_scriptWindow);
-        pyDoc->setHighlightingMode("python");
+        pyDoc->setMode(QStringLiteral("Python"));
 
         // create main toolbar
         auto toolbar = new QToolBar(m_scriptWindow);


### PR DESCRIPTION
Look at bottom right corner.

Before:

<img width="633" height="309" alt="Screenshot 2026-02-12 at 17 00 35" src="https://github.com/user-attachments/assets/46f5c3e6-37b2-49d9-9d52-97c710d33b8e" />

After:

<img width="632" height="315" alt="Screenshot 2026-02-12 at 16 57 30" src="https://github.com/user-attachments/assets/d27f3862-f0b1-46bf-886b-87e58f9d7b65" />

---

With `Normal` editor if you `ctrl+v` this:

```python
def start():
    is_output = True


def run():
    x = 1
```

the editor does some "smart" thing and you get:

```python
def start():
    is_output = True
    
    
    def run():
        x = 1
```

Very nasty 🥵