### PR TITLE
camera-arv: Avoid MTU warnings for USB cameras

### DIFF
--- a/modules/camera-arv/qarv/qarvcamera.cpp
+++ b/modules/camera-arv/qarv/qarvcamera.cpp
@@ -303,6 +303,11 @@ void QArvCamera::setMTU(int mtu) {
     emit dataChanged(QModelIndex(), QModelIndex());
 }
 
+bool QArvCamera::isGvDevice() const
+{
+    return ARV_IS_GV_DEVICE(device);
+}
+
 double QArvCamera::getExposure() {
     return arv_camera_get_exposure_time(camera, nullptr);
 }

--- a/modules/camera-arv/qarv/qarvcamera.h
+++ b/modules/camera-arv/qarv/qarvcamera.h
@@ -205,6 +205,7 @@ public:
     /**@{*/
     void setMTU(int mtu);
     int getMTU();
+    bool isGvDevice() const;
     QHostAddress getIP();
     QHostAddress getHostIP();
     int getEstimatedBW();


### PR DESCRIPTION
@ximion here is an AI-generated fix for the MTU warning I am getting for my USB camera

Any changes up to you, and feel free to wait till you can test with an Ethernet camera (I don't have any)

Just a small enhancement to not have unrelated errors in the terminal