### PR TITLE
camera-arv: Save floats with maximum precision

### DIFF
--- a/modules/camera-arv/qarv/qarvfeaturetree.cpp
+++ b/modules/camera-arv/qarv/qarvfeaturetree.cpp
@@ -143,7 +143,8 @@ void QArvCamera::QArvFeatureTree::recursiveSerialization(
         out << "String\t" << arv_gc_string_get_value(ARV_GC_STRING(node), NULL)
             << Qt::endl;
     } else if (ARV_IS_GC_FLOAT(node)) {
-      out << "Float\t" << arv_gc_float_get_value(ARV_GC_FLOAT(node), NULL)
+      out << "Float\t"
+          << QString::number(arv_gc_float_get_value(ARV_GC_FLOAT(node), NULL), 'g', 17)
           << "\t" << arv_gc_float_get_unit(ARV_GC_FLOAT(node)) << Qt::endl;
     } else if (ARV_IS_GC_BOOLEAN(node)) {
         out << "Boolean\t" << arv_gc_boolean_get_value(ARV_GC_BOOLEAN(node),


### PR DESCRIPTION
This fixes https://github.com/syntalos/syntalos/issues/41#issuecomment-3885148416

AI-suggested fix. I tested it and it indeed solved it for me. You have better understanding if this is a good or not fix, what else needs to be fixed etc.

Under the good the issue is that `12.01` is actually `12.0092075634` (and maybe even more digits) which is the true upper bound reported by the arv API (GPT wrote a quick probing tool in C to play around with read/write).

Setting it to `12.0092` makes it round to `11.9931671347`. And e.g. `12.0093` rounds it to the correct upper bound (`12.0092075634`). 