### PR TITLE
Fix uninitialized m_realFps

### DIFF
--- a/modules/camera-arv/configwindow.cpp
+++ b/modules/camera-arv/configwindow.cpp
@@ -45,6 +45,7 @@ using namespace QArv;
 ArvConfigWindow::ArvConfigWindow(const QString &modId, QWidget *parent)
     : QMainWindow(parent),
       m_modId(modId),
+      m_previewFpsCaptured(false),
       camera(nullptr),
       decoder(nullptr),
       playing(false),
@@ -504,6 +505,7 @@ void ArvConfigWindow::toggleVideoPreview(bool start)
 
             // we only record with a low framerate for the preview
             m_realFps = camera->getFPS();
+            m_previewFpsCaptured = true;
             camera->setFPS(10);
             pixelFormatSelector->setEnabled(false);
             camera->startAcquisition();
@@ -511,7 +513,11 @@ void ArvConfigWindow::toggleVideoPreview(bool start)
     } else if (!start && started) {
         started = false;
         camera->stopAcquisition();
-        camera->setFPS(m_realFps);
+
+        // External run teardown also lands here; only restore preview baseline if it was captured.
+        if (m_previewFpsCaptured)
+            camera->setFPS(m_realFps);
+        m_previewFpsCaptured = false;
         decoder.reset();
 
         setCameraInUse(false);

--- a/modules/camera-arv/configwindow.h
+++ b/modules/camera-arv/configwindow.h
@@ -129,6 +129,7 @@ private:
     QString m_modId;
     QMetaObject::Connection m_debugConnection;
     int m_realFps;
+    bool m_previewFpsCaptured;
     std::shared_ptr<QArvCamera> camera;
     std::shared_ptr<QArvDecoder> decoder;
 


### PR DESCRIPTION
This is a follow up from #41 

The reason my syntalos gets "sporadically" `Killed` is due to a buggy control flow and an uninitialised `m_realFps` in some cases. I have video that show the problem in more detail if needed, but the gist is that `m_realFps` has some random massive value from garbage memory and when Syntalos uses it it gets clapped to the max allowed by the camera (the `1000000` value) which eventually spikes memory allocation attempt and leads to the `Killed`.

NB AI-generated solution. It seemed to fix the bug. Tweak as needed

---

### How I reproduce the issue (sometimes)

I save a board with e.g. 60 FPS, close Syntalos and basler_aca640_gain_probe.c (Codex-written tool that allows to read/write Aravis settings directly outside Syntalos) reports `AcquisitionFrameRate: 60.0024000960 Hz`.

Then I open syntalos again change FPS to 61 FPS, do NOT save the board, close syntalos. probe reports `AcquisitionFrameRate: 61.0016470445 Hz`.

Open syntalos and I get the error pop up:
```
camera-arv-1: [09:39:51] Setting failure, wanted: "\tAcquisitionFrameRate\tFloat\t60.002400096003839\tHz" 
camera-arv-1: [09:39:51] actual: "\tAcquisitionFrameRate\tFloat\t61.001647044470204\tHz" 
```

I dismiss it and start an ephemeral run, all good camera working, I stop the run, all good so far. I try running a second ephemeral run and syntalos gets `Killed`. Probe reports `AcquisitionFrameRate: 1000000.00 Hz`

## What Codex identified:

- m_realFps is used uninitialized in the external run stop path, which can write garbage FPS (often clamped to max).
- Declared but not initialized: configwindow.h (line 131)
- Constructor does not initialize it: configwindow.cpp (line 45)
- External stop path calls preview-stop logic and restores camera->setFPS(m_realFps): configwindow.cpp (line 511) and configwindow.cpp (line 514)
- Immediately after, setCameraInUse(false) re-applies fpsSpinbox->value(), which can already have been updated to the bad value via dataChanged: configwindow.cpp (line 460)

## What else Codex seems to have spotted:

Advanced feature restore parser is structurally incompatible with serialized format.
- Serializer writes category lines as Category: ...: qarvfeaturetree.cpp (line 110)
- Parser only skips Category (no colon): qarvcamera.cpp (line 576)
- Serializer writes float units (Hz, us, dB): qarvfeaturetree.cpp (line 146)
- Parser reads only 3 whitespace tokens (name type value), so unit tokens desynchronize parsing: qarvcamera.cpp (line 581)

I have no idea if there is a real issue regarding this or not.

---

I am still getting the FPS setting warning, which I would expect to not happen, even if camera settings have been changed externally or during syntalos previous run (without saving the board) it should just override the setting and not complain. The setting in the board should be the source of truth. Perhaps this is the quirk of GenICams you have been mentioning, or perhaps related to all of the above.