### PR TITLE
videotransform: fix crop region selector coordinates for resized windows

### DIFF
--- a/modules/videotransform/videotransform.cpp
+++ b/modules/videotransform/videotransform.cpp
@@ -184,11 +184,15 @@ void CropTransform::createSettingsUi(QWidget *parent)
 
         auto dlg = new KPixmapRegionSelectorDialog(parent);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->pixmapRegionSelectorWidget()->setPixmap(pixmap.value());
+        auto selector = dlg->pixmapRegionSelectorWidget();
+        selector->setPixmap(pixmap.value());
 
-        // Pre-select the current ROI
+        // Pre-select the current ROI in the original image coordinates
         if (m_roi.width > 0 && m_roi.height > 0)
-            dlg->pixmapRegionSelectorWidget()->setSelectedRegion(QRect(m_roi.x, m_roi.y, m_roi.width, m_roi.height));
+            selector->setSelectedRegion(QRect(m_roi.x, m_roi.y, m_roi.width, m_roi.height));
+        // Adjust the dialog size to fit the screen, the image size on screen will be fixed
+        // even if the user maximizes the dialog.
+        dlg->adjustRegionSelectorWidgetSizeToFitScreen();
 
         connect(dlg, &QDialog::accepted, [this, dlg]() {
             const QRect selected = dlg->pixmapRegionSelectorWidget()->unzoomedSelectedRegion();


### PR DESCRIPTION
Problem: https://www.youtube.com/watch?v=uqF7kAECRwo

Can be reproduced directly only if the resolution of the input frames is bigger (1600x1200 in my case) than the available space on the screen for the crop selector widget window to fit in.

The actual coordinates of the selected ROI are wrongly saved leading to incorrect ROI at the output of the Video Transformer module.

Codex-suggested fix. It seems the issue is upstream `Qlabel` defaults to `AlignLeft  | AlignVCenter` but we need `AlignLeft | AlignTop` here. `KPixmapRegionSelectorWidget` is not doing that

I reproduced the issue and tested the fix only on X11.

---

If you look into it mind the following remaining issues:

- it is not possible to resize the window for big resolution frames. Maximising the window works to force the full widget to be visible on the screen (image gets distorted, does not preserver aspect ratio), this PR makes it usable at least and the `OK` button is visible for clicking
- it does not clear/reset the frame used for selecting the crop region when (re)starting a new Syntalos run, a bit inconvenient