### PR TITLE
canvas: Fix black frames for oddly sized frames or crops

### DIFF
--- a/modules/canvas/imageviewwidget.cpp
+++ b/modules/canvas/imageviewwidget.cpp
@@ -279,6 +279,10 @@ void ImageViewWidget::renderImage()
     const auto imgHeight = d->glImage.rows;
     const auto channels = d->glImage.channels();
 
+    // Canvas receives arbitrary crop widths, so we must not rely on OpenGL's default
+    // 4-byte unpack alignment when uploading rows.
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
     // Setup or recreate texture only when dimensions change
     if (d->textureId == 0 || d->textureWidth != imgWidth || d->textureHeight != imgHeight) {
         if (d->textureId != 0)


### PR DESCRIPTION
@ximion when cropping (specially via the handy Select Region) you don't always end up with a "nice" frame size, `GL_UNPACK_ALIGNMENT = 4` by default and leads to a black Canvas. 

Very annoying, took a while to get to the bottom of it because I was run into other crashes (#70, #71 , #72) and had no idea what I was really chasing 🥵