### PR TITLE
[Draft] Fix mem pool issue by refreshing the persistent IPC sender

### DIFF
--- a/src/mlink/syntaloslink.cpp
+++ b/src/mlink/syntaloslink.cpp
@@ -214,6 +214,7 @@ public:
         reqShutdown = makeServer<ShutdownRequest, DoneResponse>(SHUTDOWN_CALL_ID);
         reqShowDisplay = makeServer<ShowDisplayRequest, DoneResponse>(SHOW_DISPLAY_CALL_ID);
         reqShowSettings = makeUntypedServer(SHOW_SETTINGS_CALL_ID);
+        refreshPersistentIpcSendersPending = false;
     }
 
     ~Private() {}
@@ -304,6 +305,102 @@ public:
         return subscr;
     }
 
+    void schedulePersistentIpcSenderRefresh()
+    {
+        refreshPersistentIpcSendersPending = true;
+    }
+
+    void runDeferredMaintenance()
+    {
+        if (!refreshPersistentIpcSendersPending)
+            return;
+
+        refreshPersistentIpcSendersPending = false;
+        refreshPersistentIpcSenders();
+    }
+
+    void refreshPersistentIpcSenders()
+    {
+        auto recyclePublisher = [&](auto &publisher, auto &&factory, const char *endpointName) {
+            publisher.reset();
+            publisher = factory();
+        };
+
+        auto recycleServer = [&](auto &server, auto &&factory, const char *endpointName) {
+            if (server != nullptr) {
+                waitSet.detachState(*server, iox::popo::ServerState::HAS_REQUEST);
+                server->releaseQueuedRequests();
+            }
+            server.reset();
+            server = factory();
+        };
+
+        recyclePublisher(pubError, [&]() { return makePublisher<ErrorEvent>(ERROR_CHANNEL_ID); }, "pubError");
+        recyclePublisher(pubState, [&]() { return makePublisher<StateChangeEvent>(STATE_CHANNEL_ID); }, "pubState");
+        recyclePublisher(
+            pubStatusMessage,
+            [&]() { return makePublisher<StatusMessageEvent>(STATUS_MESSAGE_CHANNEL_ID, false); },
+            "pubStatusMessage");
+        recyclePublisher(
+            pubSettingsChange,
+            [&]() { return makeUntypedPublisher(SETTINGS_CHANGE_CHANNEL_ID); },
+            "pubSettingsChange");
+        recyclePublisher(pubInPortChange, [&]() { return makeUntypedPublisher(IN_PORT_CHANGE_CHANNEL_ID); }, "pubInPortChange");
+        recyclePublisher(
+            pubOutPortChange,
+            [&]() { return makeUntypedPublisher(OUT_PORT_CHANGE_CHANNEL_ID); },
+            "pubOutPortChange");
+
+        recycleServer(
+            reqSetNiceness,
+            [&]() { return makeServer<SetNicenessRequest, DoneResponse>(SET_NICENESS_CALL_ID); },
+            "reqSetNiceness");
+        recycleServer(
+            reqSetMaxRTPriority,
+            [&]() { return makeServer<SetMaxRealtimePriority, DoneResponse>(SET_MAX_RT_PRIORITY_CALL_ID); },
+            "reqSetMaxRTPriority");
+        recycleServer(
+            reqSetCPUAffinity,
+            [&]() { return makeServer<SetCPUAffinityRequest, DoneResponse>(SET_CPU_AFFINITY_CALL_ID); },
+            "reqSetCPUAffinity");
+        recycleServer(reqLoadScript, [&]() { return makeUntypedServer(LOAD_SCRIPT_CALL_ID); }, "reqLoadScript");
+        recycleServer(
+            reqSetPortsPreset,
+            [&]() { return makeUntypedServer(SET_PORTS_PRESET_CALL_ID); },
+            "reqSetPortsPreset");
+        recycleServer(
+            reqUpdateIPortMetadata,
+            [&]() { return makeUntypedServer(IN_PORT_UPDATE_METADATA_ID); },
+            "reqUpdateIPortMetadata");
+        recycleServer(
+            reqConnectIPort,
+            [&]() { return makeServer<ConnectInputRequest, DoneResponse>(CONNECT_INPUT_CALL_ID); },
+            "reqConnectIPort");
+        recycleServer(
+            reqPrepareStart,
+            [&]() { return makeUntypedServer(PREPARE_START_CALL_ID); },
+            "reqPrepareStart");
+        recycleServer(reqStart, [&]() { return makeServer<StartRequest, DoneResponse>(START_CALL_ID); }, "reqStart");
+        recycleServer(reqStop, [&]() { return makeServer<StopRequest, DoneResponse>(STOP_CALL_ID); }, "reqStop");
+        recycleServer(
+            reqShutdown,
+            [&]() { return makeServer<ShutdownRequest, DoneResponse>(SHUTDOWN_CALL_ID); },
+            "reqShutdown");
+        recycleServer(
+            reqShowDisplay,
+            [&]() { return makeServer<ShowDisplayRequest, DoneResponse>(SHOW_DISPLAY_CALL_ID); },
+            "reqShowDisplay");
+        recycleServer(
+            reqShowSettings,
+            [&]() { return makeUntypedServer(SHOW_SETTINGS_CALL_ID); },
+            "reqShowSettings");
+
+        for (auto &oport : outPortInfo) {
+            oport->d->ioxPub.reset();
+            oport->d->ioxPub = makeUntypedPublisher(oport->d->publisherId());
+        }
+    }
+
     iox::capro::IdString_t modId;
 
     std::unique_ptr<iox::popo::Publisher<ErrorEvent>> pubError;
@@ -342,6 +439,7 @@ public:
     ShutdownFn shutdownCb;
     ShowSettingsFn showSettingsCb;
     ShowDisplayFn showDisplayCb;
+    bool refreshPersistentIpcSendersPending;
 };
 
 SyntalosLink::SyntalosLink(const QString &instanceId, QObject *parent)
@@ -393,8 +491,10 @@ void SyntalosLink::awaitData(int timeoutUsec)
             // process events here.
             const auto qevTimeout = iox::units::Duration::fromMicroseconds(250 * 1000); // 250ms timeout
             auto notificationVector = d->waitSet.timedWait(qevTimeout);
-            for (auto &notification : notificationVector)
+            for (auto &notification : notificationVector) {
                 processNotification(notification);
+                d->runDeferredMaintenance();
+            }
 
             qApp->processEvents();
             if (!notificationVector.empty())
@@ -402,8 +502,10 @@ void SyntalosLink::awaitData(int timeoutUsec)
         }
     } else {
         auto notificationVector = d->waitSet.timedWait(iox::units::Duration::fromMicroseconds(timeoutUsec));
-        for (auto &notification : notificationVector)
+        for (auto &notification : notificationVector) {
             processNotification(notification);
+            d->runDeferredMaintenance();
+        }
         qApp->processEvents();
     }
 }
@@ -414,6 +516,7 @@ void SyntalosLink::awaitDataForever()
         auto notificationVector = d->waitSet.wait();
         for (auto &notification : notificationVector) {
             processNotification(notification);
+            d->runDeferredMaintenance();
             qApp->processEvents();
         }
     }
@@ -755,6 +858,7 @@ void SyntalosLink::processNotification(const iox::popo::NotificationInfo *notifi
                     response.send().or_else([&](auto &error) {
                         std::cerr << "Could not respond to Stop! Error: " << error << std::endl;
                     });
+                    d->schedulePersistentIpcSenderRefresh();
                 })
                 .or_else([&](auto &error) {
                     std::cerr << "Could not allocate response! Error: " << error << std::endl;


### PR DESCRIPTION
@ximion I might have reached the bottom of my rabbit hole 🐇🕳️ 

Codex finally came up with a patch that at least seems to prevent #60 from happening during my testing.

I am not qualified to judge if it really identified the real root cause of #60 or it go lucky with the proposed change.

I used the "Extra High" thinking/effort mode, very curious to know if it was worth spending these LLM tokens 😂

---

Its hypothesis was:

> long-lived iceoryx senders keep one cached chunk each in `m_lastChunkUnmanaged`, and because the worker processes are reused across runs, those cached small control chunks accumulate instead of returning between runs. That matches both the log and the `iceoryx` implementation: `chunk_sender.inl` (line 106), `chunk_sender.inl` (line 193), `chunk_sender.inl` (line 251).

---

If the identified cause is real, perhaps the following Codex suggestions are useful on deciding on the right fix (feel free to ignore, might be slop):

> The clean alternatives, ordered from most pragmatic to most elegant, are:
> 
> **Restart each worker process between runs.** This is the simplest robust fix. It guarantees all iceoryx ports and cached chunks disappear. The downside is extra startup cost and losing any warm in-process state.

I tested this, it works indeed as reported in https://github.com/syntalos/syntalos/issues/60#issuecomment-4056748732

> **Make the worker IPC layer run-scoped instead of process-scoped.** In SyntalosLink, keep module callbacks, timer, and port definitions alive, but create all iceoryx publishers/servers only for one run and destroy them on stop(). This is basically the clean version of the fix we just proved.
> 
> **Refactor the iceoryx ownership into one transport subobject and rebuild that subobject per run.** For example, move pub*, req*, waitset wiring, and output ioxPub ownership into a TransportState owned by SyntalosLink::Private. Then stop() just destroys TransportState and prepare() recreates it. This is cleaner than individually refreshing 20+ members.
> 
> **Make only sender-backed objects run-scoped.** Keep input subscribers and higher-level state persistent, but recreate fixed publishers, fixed servers, and output publishers on each run. This is the smallest architectural change that still targets the real cause.
> 
> **Create low-volume control publishers on demand.** pubSettingsChange, pubInPortChange, pubOutPortChange, and possibly pubStatusMessage do not need to live forever. A temporary publisher per send is simple and avoids keeping cached chunks in those channels.
> 
> **Create output publishers lazily and destroy them on stop.** Output stream publishers are a natural run-scoped resource. This reduces persistent sender count without touching the whole control plane.
> 
> **Collapse many fixed RPC servers into one generic command server.** Right now each worker has many long-lived server objects. A single command server plus a small dispatcher would reduce the number of persistent sender objects a lot. This is elegant, but it is a protocol refactor.
> 
> **Move the control plane off iceoryx entirely.** Keep data streams on iceoryx, but use Qt local sockets, DBus, or another simple IPC mechanism for commands and metadata. This avoids the cached-chunk behavior on the control path. It is the cleanest long-term design, but also the biggest change.
> 
> **Keep the current fix, but formalize it as an explicit reset API.** Instead of “deep refresh” logs and manual member-by-member recreation, add something like SyntalosLink::resetTransportForNextRun(). That keeps the proven behavior while making the code less ad hoc.