### PR TITLE
Implement configurable global external module timeout

### DIFF
--- a/src/fabric/globalconfig.cpp
+++ b/src/fabric/globalconfig.cpp
@@ -137,6 +137,25 @@ void GlobalConfig::setDefaultRTThreadPriority(int priority)
     m_s->setValue("engine/default_rt_thread_priority", priority);
 }
 
+int GlobalConfig::externalModulePrepareTimeoutSec() const
+{
+    int timeoutSec = m_s->value("engine/external_module_prepare_timeout_sec", 10).toInt();
+    if (timeoutSec < 1)
+        timeoutSec = 1;
+    else if (timeoutSec > 600)
+        timeoutSec = 600;
+    return timeoutSec;
+}
+
+void GlobalConfig::setExternalModulePrepareTimeoutSec(int timeoutSec)
+{
+    if (timeoutSec < 1)
+        timeoutSec = 1;
+    else if (timeoutSec > 600)
+        timeoutSec = 600;
+    m_s->setValue("engine/external_module_prepare_timeout_sec", timeoutSec);
+}
+
 bool GlobalConfig::explicitCoreAffinities() const
 {
     return m_s->value("engine/explicit_core_affinities", false).toBool();

--- a/src/fabric/globalconfig.h
+++ b/src/fabric/globalconfig.h
@@ -66,6 +66,9 @@ public:
     int defaultRTThreadPriority() const;
     void setDefaultRTThreadPriority(int priority);
 
+    int externalModulePrepareTimeoutSec() const;
+    void setExternalModulePrepareTimeoutSec(int timeoutSec);
+
     bool explicitCoreAffinities() const;
     void setExplicitCoreAffinities(bool enabled);
 

--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -803,6 +803,8 @@ void MLinkModule::disconnectOutPortForwarders()
 bool MLinkModule::prepare(const TestSubject &subject)
 {
     GlobalConfig gconf;
+    const auto timeoutSec = gconf.externalModulePrepareTimeoutSec();
+    const auto timeoutMsec = timeoutSec * 1000;
 
     // ensure we are reading any messages from the module process
     d->ctlEventTimer->start();
@@ -847,9 +849,10 @@ bool MLinkModule::prepare(const TestSubject &subject)
         if (state() == ModuleState::ERROR)
             return false;
 
-        // wait 10sec for the module to become ready
-        if (timer.elapsed() > 10000) {
-            raiseError("Timeout while waiting for module. Module did not transition to 'ready' state in time.");
+        if (timer.elapsed() > timeoutMsec) {
+            raiseError(QStringLiteral("Timeout while waiting for module. Module did not transition to 'ready' state "
+                                      "within %1 seconds.")
+                           .arg(timeoutSec));
             return false;
         }
     }

--- a/src/globalconfigdialog.cpp
+++ b/src/globalconfigdialog.cpp
@@ -55,6 +55,7 @@ GlobalConfigDialog::GlobalConfigDialog(QWidget *parent)
         ui->colorModeComboBox->setCurrentIndex(static_cast<int>(m_gc->appColorMode()));
     }
     ui->cbEmergencyOOMStop->setChecked(m_gc->emergencyOOMStop());
+    ui->externalModulePrepareTimeoutSpinBox->setValue(m_gc->externalModulePrepareTimeoutSec());
 
     // advanced section
     ui->defaultNicenessSpinBox->setMaximum(20);
@@ -111,6 +112,12 @@ void GlobalConfigDialog::on_cbEmergencyOOMStop_toggled(bool checked)
 {
     if (m_acceptChanges)
         m_gc->setEmergencyOOMStop(checked);
+}
+
+void GlobalConfigDialog::on_externalModulePrepareTimeoutSpinBox_valueChanged(int arg1)
+{
+    if (m_acceptChanges)
+        m_gc->setExternalModulePrepareTimeoutSec(arg1);
 }
 
 void GlobalConfigDialog::on_defaultNicenessSpinBox_valueChanged(int arg1)

--- a/src/globalconfigdialog.h
+++ b/src/globalconfigdialog.h
@@ -41,6 +41,7 @@ public:
 private slots:
     void on_colorModeComboBox_currentIndexChanged(int index);
     void on_cbEmergencyOOMStop_toggled(bool checked);
+    void on_externalModulePrepareTimeoutSpinBox_valueChanged(int arg1);
 
     void on_defaultNicenessSpinBox_valueChanged(int arg1);
     void on_defaultRTPrioSpinBox_valueChanged(int arg1);

--- a/src/globalconfigdialog.ui
+++ b/src/globalconfigdialog.ui
@@ -163,6 +163,32 @@
                <item row="0" column="1">
                 <widget class="QCheckBox" name="cbEmergencyOOMStop"/>
                </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="externalModulePrepareTimeoutLabel">
+                 <property name="text">
+                  <string>External module prepare timeout</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QSpinBox" name="externalModulePrepareTimeoutSpinBox">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum time Syntalos waits for external modules, including Python modules, to finish preparing and report the ready state.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="suffix">
+                  <string> s</string>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>600</number>
+                 </property>
+                 <property name="value">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </item>
             </layout>


### PR DESCRIPTION
Some of my devices may require connection retries etc. that can easily go beyond the hardcoded 10s prepare timeout