### PR TITLE
python: Fix numpy signal block annotations and create docs from stub file

### DIFF
--- a/src/python/make-pydocs.py
+++ b/src/python/make-pydocs.py
@@ -55,7 +55,11 @@ def generate_docs_file(source_file, out_fname):
         with open(os.path.join(tpl_dir, 'frame.html.jinja2'), 'w') as f:
             f.write(JINJA_TEMPLATE)
 
-        staged_source = os.path.join(tmp_dir, os.path.basename(source_file))
+        staged_basename = os.path.basename(source_file)
+        if staged_basename.endswith('.pyi'):
+            # pdoc expects an importable Python module path, so stage stubs as .py files.
+            staged_basename = staged_basename[:-1]
+        staged_source = os.path.join(tmp_dir, staged_basename)
         with open(source_file, 'r') as sf:
             with open(staged_source, 'w') as df:
                 for line in sf.readlines():

--- a/src/python/meson.build
+++ b/src/python/meson.build
@@ -125,7 +125,12 @@ pb11_stubgen_exe = find_program('pybind11-stubgen', required: false)
 if pb11_stubgen_exe.found()
     pysy_mlink_stub = custom_target('pysy-mlink-stubgen',
         build_by_default: true,
-        command: [pb11_stubgen_exe, '-o', meson.current_build_dir(), 'syntalos_mlink'],
+        command: [
+            pb11_stubgen_exe,
+            '--numpy-array-wrap-with-annotated',
+            '-o', meson.current_build_dir(),
+            'syntalos_mlink'
+        ],
         depends: [pysy_mlink_mod],
         input: pysy_mlink_mod,
         output: 'syntalos_mlink.pyi',
@@ -142,14 +147,13 @@ if have_python_pdoc and pb11_stubgen_exe.found()
     pysy_mlink_doc_fname = source_root / 'docs' / 'pysy_mlink_api_embed.html'
     custom_target('pysy-mlink-mkdoc',
         build_by_default: true,
+        input: [pysy_mlink_stub],
         command: [
             python, make_pydocs_exe.full_path(),
             'generate',
-            '--module', 'syntalos_mlink',
+            '--file', '@INPUT0@',
             '@OUTPUT0@'
         ],
-        depends: [pysy_mlink_stub, pysy_mlink_mod],
         output: 'pysy_mlink_api_embed.html',
-        env: {'PYTHONPATH': meson.current_build_dir()},
     )
 endif


### PR DESCRIPTION
Follow up from https://github.com/syntalos/syntalos/issues/107#issuecomment-4217228713, generating the stub worked but with errors:

```bash
Found ninja-1.12.1 at /usr/bin/ninja
[389/641] Generating src/python/pysy-mlink-stubgen with a custom command (wrapped by meson to set env)
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.data. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.data. : Can't find/import 'n'
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.data. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.data. : Can't find/import 'n'
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.timestamps. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.FloatSignalBlock.timestamps. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.data. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.data. : Can't find/import 'n'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.data. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.data. : Can't find/import 'n'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.timestamps. : Can't find/import 'm'
pybind11_stubgen - [  ERROR] In syntalos_mlink.IntSignalBlock.timestamps. : Can't find/import 'm'
[560/641] Generating src/python/pysy-mlink-mkdoc with a custom command (wrapped by meson to set env)
/usr/lib/python3/dist-packages/pdoc/doc_types.py:148: UserWarning: Error parsing type annotation numpy.ndarray[numpy.int32[m, n]] for syntalos_mlink.IntSignalBlock.data. Import of m failed: name 'm' is not defined
  warnings.warn(
/usr/lib/python3/dist-packages/pdoc/doc_types.py:148: UserWarning: Error parsing type annotation numpy.ndarray[numpy.uint64[m, 1]] for syntalos_mlink.IntSignalBlock.timestamps. Import of m failed: name 'm' is not defined
  warnings.warn(
/usr/lib/python3/dist-packages/pdoc/doc_types.py:148: UserWarning: Error parsing type annotation numpy.ndarray[numpy.float64[m, n]] for syntalos_mlink.FloatSignalBlock.data. Import of m failed: name 'm' is not defined
  warnings.warn(
/usr/lib/python3/dist-packages/pdoc/doc_types.py:148: UserWarning: Error parsing type annotation numpy.ndarray[numpy.uint64[m, 1]] for syntalos_mlink.FloatSignalBlock.timestamps. Import of m failed: name 'm' is not defined
  warnings.warn(
[641/641] Linking target src/syntalos
```

Fixes Python stub/doc generation warnings for signal block NumPy types

Makes `pybind11-stubgen` emit valid NumPy `Annotated` array types and generates the embedded Python API docs from the generated stub file. This removes the `IntSignalBlock` / `FloatSignalBlock` annotation warnings during the Syntalos build.

NB Codex-implemented...

PS maybe mention the `pybind11-stubgen` trick in `syntalos-web` docs