### PR TITLE
python: Allow using print() instead of syl.println()

### DIFF
--- a/src/moduleloader-py.cpp
+++ b/src/moduleloader-py.cpp
@@ -123,10 +123,14 @@ public:
         if (!existingPythonPath.isEmpty())
             pythonPath << existingPythonPath.split(':', Qt::SkipEmptyParts);
         pythonPath.removeDuplicates();
-        if (!pythonPath.isEmpty()) {
+        if (!pythonPath.isEmpty())
             penv.insert(QStringLiteral("PYTHONPATH"), pythonPath.join(':'));
-            setModuleBinaryEnv(penv);
-        }
+
+        // Python stdout is block-buffered when connected to QProcess pipes, which
+        // makes ordinary print() output appear only when the worker exits. Keep
+        // module output interactive so print() behaves like syl.println().
+        penv.insert(QStringLiteral("PYTHONUNBUFFERED"), QStringLiteral("1"));
+        setModuleBinaryEnv(penv);
 
         // Resolve interpreter: use the venv's python when a venv is requested.
         // setPythonVirtualEnv() tells runProcess() to set VIRTUAL_ENV and prepend


### PR DESCRIPTION
See comment in the code.

Is there some deeper reason why `syl.println()` exists in the Python module, compared to what this PR proposes?

Maybe it is needed for PyScript, though that one has its own logging window under the editor 🤔

In any case it would be nice to support Python's native `print()`, it is way more natural to use inside Python. Beside that some dependencies packages might be printing relevant things too that get "suppressed" (i.e. buffered) until closing Syntalos, at which point all the prints are flushed.

This PR should also allow to use a proper logger (e.g. Python's `logging`)