### PR TITLE
mlink: Allow show settings to be invoked when module is in ERROR state

### DIFF
--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -786,7 +786,7 @@ bool MLinkModule::loadSettings(const QString &confBaseDir, const QVariantHash &s
 
 void MLinkModule::showDisplayUi()
 {
-    if (!d->callClientSimple<ShowDisplayRequest>(this, SHOW_DISPLAY_CALL_ID, [](auto &) {}))
+    if (!d->callClientSimple<ShowDisplayRequest>(this, SHOW_DISPLAY_CALL_ID, [](auto &) {}, 5, true, false))
         LOG_WARNING(m_log, "Show display request failed!");
 }
 

--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -795,7 +795,7 @@ void MLinkModule::showSettingsUi()
     // pick up any recently saved settings before we hand them back to the worker UI
     handleIncomingControl();
 
-    if (!d->callClientSimple<ShowSettingsRequest>(this, SHOW_SETTINGS_CALL_ID, [](auto &) {}))
+    if (!d->callClientSimple<ShowSettingsRequest>(this, SHOW_SETTINGS_CALL_ID, [](auto &) {}, 5, true, false))
         LOG_WARNING(m_log, "Request to show settings UI has failed!");
 
     // drain immediate updates emitted while handling the request


### PR DESCRIPTION
This is the solution that has been preventing my Python Modules to open the settings after an Exception has been raised, either handled (via `syntax_mlink.raise()`) or unhandled (letting the exception be raised in Python, which is handy since it now prints the traceback in red in `syntalos` output.

Currently the function passed to `await_data_forever()` continues to be called in the ERROR state, so I would say there is no reason to not allow show settings to be called too