### PR TITLE
python: Fix setproctitle fallback

### DIFF
--- a/src/python/pysy-mlink.cpp
+++ b/src/python/pysy-mlink.cpp
@@ -332,19 +332,24 @@ public:
             // argv[], which Python does not provide. Rather than doing the horrendous
             // memory-scanning of setproctitle ourselves, we might as well call the real
             // thing, if it is installed.
-            sptMod = py::module_::import("setproctitle");
+            try {
+                sptMod = py::module_::import("setproctitle");
+            } catch (py::error_already_set &e) {
+                if (!e.matches(PyExc_ImportError))
+                    throw;
+            }
 
             // if we have setproctitle, we prefer it over Syntalos' simple thread-renaming
-            if (!sptMod.is_none())
+            if (sptMod)
                 newOptn.renameThread = false;
         }
 
         // connect
-        m_ownedSLink = initSyntalosModuleLink(optn);
+        m_ownedSLink = initSyntalosModuleLink(newOptn);
         m_slink = m_ownedSLink.get();
 
         // do the renaming, if the user wanted it
-        if (optn.renameThread && !sptMod.is_none())
+        if (optn.renameThread && sptMod)
             sptMod.attr("setproctitle")(m_slink->instanceId());
     }
 


### PR DESCRIPTION
Follow up from edaca57b0250f8e5be0f4758611be8120d645f4d

The fallback logic was faulty, newOptn not used.

Codex explanation (before this PR):

> init_link(rename_process=True) now hard-requires setproctitle, despite the fallback path.
pysy-mlink.cpp (line 335) directly imports setproctitle; if it is not installed, pybind throws before initSyntalosModuleLink() can do the simpler /proc/self/comm fallback. Also, newOptn is computed but not used at pysy-mlink.cpp (line 343), so even when setproctitle exists, the intended “prefer setproctitle over simple rename” path is not actually applied.