### PR TITLE
Firmata: Preserve qFatal() behavior and abort on critical errors

### DIFF
--- a/modules/firmata-io/firmata/backend.cpp
+++ b/modules/firmata-io/firmata/backend.cpp
@@ -254,7 +254,7 @@ void FirmataBackend::writeDigitalPin(uint8_t pin, bool value)
         writeBuffer(buffer, sizeof(buffer));
 
     } else {
-        LOG_CRITICAL(d->log, "Pin %d not supported (max is 127)", pin);
+        LOG_CRITICAL(d->log, "Pin {} not supported (max is 127)", pin);
     }
 }
 
@@ -266,7 +266,7 @@ void FirmataBackend::reportAnalogPin(uint8_t pin, bool enable)
         writeBuffer(buffer, sizeof(buffer));
 
     } else {
-        LOG_CRITICAL(d->log, "Reporting analog channel %d is not supported (max is 15)", pin);
+        LOG_CRITICAL(d->log, "Reporting analog channel {} is not supported (max is 15)", pin);
     }
 }
 

--- a/modules/firmata-io/firmata/backend.cpp
+++ b/modules/firmata-io/firmata/backend.cpp
@@ -18,6 +18,8 @@
 #include "backend.h"
 #include "fmutils.h"
 
+#include <cstdlib>
+
 #include <QtEndian>
 
 #include <QCoreApplication>
@@ -243,6 +245,8 @@ void FirmataBackend::writeAnalogPin(uint8_t pin, uint16_t value)
 
     } else {
         LOG_CRITICAL(d->log, "Analog pin {} not supported. Max is 127", pin);
+        d->log->flush_log();
+        std::abort();
     }
 }
 
@@ -255,6 +259,8 @@ void FirmataBackend::writeDigitalPin(uint8_t pin, bool value)
 
     } else {
         LOG_CRITICAL(d->log, "Pin {} not supported (max is 127)", pin);
+        d->log->flush_log();
+        std::abort();
     }
 }
 
@@ -267,6 +273,8 @@ void FirmataBackend::reportAnalogPin(uint8_t pin, bool enable)
 
     } else {
         LOG_CRITICAL(d->log, "Reporting analog channel {} is not supported (max is 15)", pin);
+        d->log->flush_log();
+        std::abort();
     }
 }
 
@@ -279,6 +287,8 @@ void FirmataBackend::reportDigitalPort(uint8_t port, bool enable)
 
     } else {
         LOG_CRITICAL(d->log, "Digital port {} not supported (max is 15)", port);
+        d->log->flush_log();
+        std::abort();
     }
 }
 
@@ -297,6 +307,8 @@ void FirmataBackend::setPinMode(uint8_t pin, IoMode mode)
 
     } else {
         LOG_CRITICAL(d->log, "Pins over 127 ({}) not supported", pin);
+        d->log->flush_log();
+        std::abort();
     }
 }
 


### PR DESCRIPTION
Codex explanation:

> Critical Firmata validation errors are no longer fatal.
Several qFatal() calls were changed to LOG_CRITICAL() in backend.cpp (line 245), backend.cpp (line 257), backend.cpp (line 269), etc. Quill critical logging does not abort, so invalid pin/channel paths now return normally instead of stopping on a caller contract violation. Two messages also still use %d, so the pin value will not be formatted correctly with Quill/fmt.

I assume the behaviour change was not intentional, hence the PR