### PR TITLE
trivial: More logging cleanup that passed by unnoticed on QDebug removal

### DIFF
--- a/modules/triled-tracker/tracker.cpp
+++ b/modules/triled-tracker/tracker.cpp
@@ -27,6 +27,8 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
+#include "fabric/logging.h"
+
 Tracker::Tracker(std::shared_ptr<DataStream<TableRow>> dataStream, const QString &subjectId)
     : QObject(nullptr),
       m_initialized(false),
@@ -41,7 +43,7 @@ Tracker::Tracker(std::shared_ptr<DataStream<TableRow>> dataStream, const QString
         file.read((char *)buf.data(), sz);
         m_mouseGraphicMat = cv::imdecode(buf, cv::IMREAD_COLOR);
     } else {
-        qCritical() << "Unable to load mouse image from internal resources.";
+        LOG_CRITICAL(logRoot, "Unable to load mouse image from internal resources.");
     }
 }
 

--- a/src/fabric/streams/stream.h
+++ b/src/fabric/streams/stream.h
@@ -671,7 +671,7 @@ public:
         if (!m_active)
             return;
         if (typeId != syDataTypeId<T>()) {
-            qCritical().noquote() << "Invalid data type ID" << typeId << "for stream " << streamDebugId();
+            LOG_CRITICAL(m_log, "Invalid data type ID {} for stream {}", typeId, streamDebugId());
             return;
         }
 

--- a/src/fabric/sysinfo.cpp
+++ b/src/fabric/sysinfo.cpp
@@ -37,6 +37,7 @@ extern "C" {
 }
 
 #include "datactl/priv/rtkit.h"
+#include "logging.h"
 #include "utils/misc.h"
 
 using namespace Syntalos;
@@ -156,8 +157,9 @@ SysInfo::SysInfo()
     d->cpuCount = QThread::idealThreadCount();
     d->cpuPhysicalCoreCount = d->cpuCount;
 #ifndef Q_OS_LINUX
-    qCritical()
-        << "We are not building for Linux - please make sure to adjust the SysInfo code when porting to other systems!";
+    LOG_CRITICAL(
+        logRoot,
+        "We are not building for Linux - please make sure to adjust the SysInfo code when porting to other systems!");
     return;
 #endif
 
@@ -486,7 +488,7 @@ void SysInfo::readCPUInfo()
 {
     QFile file("/proc/cpuinfo");
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qCritical() << "Unable to open /proc/cpuinfo for reading. This may be a system configuration issue.";
+        LOG_CRITICAL(logRoot, "Unable to open /proc/cpuinfo for reading. This may be a system configuration issue.");
         return;
     }
 
@@ -562,7 +564,7 @@ void SysInfo::readCPUInfo()
 
     // safeguard in case we failed to determine proper information for any reason
     if (d->cpuCount <= 0) {
-        qCritical() << "Unable to read CPU information. Is /proc/cpuinfo accessible?";
+        LOG_CRITICAL(logRoot, "Unable to read CPU information. Is /proc/cpuinfo accessible?");
         d->cpuCount = QThread::idealThreadCount();
         d->cpuPhysicalCoreCount = d->cpuCount;
     }

--- a/src/fabric/utils/tomlutils.cpp
+++ b/src/fabric/utils/tomlutils.cpp
@@ -23,6 +23,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "fabric/logging.h"
+
 toml::time qTimeToToml(const QTime &qtime)
 {
     toml::time ttime;
@@ -130,8 +132,7 @@ toml::array qVariantListToTomlArray(const QVariantList &varList)
         if (CONVERT_SIMPLE_QTYPE_TO_TOMLTYPE(arr.push_back, var))
             continue;
 
-        qWarning().noquote()
-            << QStringLiteral("Unable to store type `%1` in TOML attributes (array).").arg(var.typeName());
+        LOG_WARNING(logRoot, "Unable to store type `{}` in TOML attributes (array).", var.typeName());
         arr.push_back("�");
     }
 
@@ -165,8 +166,7 @@ toml::table qVariantHashToTomlTable(const QVariantHash &varHash)
         if (CONVERT_SIMPLE_QTYPE_TO_TOMLTYPE(tabInsertFunc, var))
             continue;
 
-        qWarning().noquote()
-            << QStringLiteral("Unable to store type `%1` in TOML attributes (table).").arg(var.typeName());
+        LOG_WARNING(logRoot, "Unable to store type `{}` in TOML attributes (table).", var.typeName());
         tab.insert(key, "�");
     }
 


### PR DESCRIPTION
Codex explanation:

> Build regression: QDebug was removed while stream-style Qt logging remains.
The range removes <QDebug> from several files, but they still use qCritical()/qWarning() streaming syntax, which requires the QDebug type. Examples: stream.h (line 674), tracker.cpp (line 44), tomlutils.cpp (line 133), sysinfo.cpp (line 159). This can fail compilation depending on transitive includes.

seems that `<QDebug>` is still sneakily included