### PR TITLE
mlink: Send stop request when module is in ERROR state

### DIFF
--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -1310,7 +1310,7 @@ void MLinkModule::runThread(OptionalWaitCondition *startWaitCondition)
 void MLinkModule::stop()
 {
     if (isProcessRunning())
-        d->callClientSimple<StopRequest>(this, STOP_CALL_ID, [](auto &) {}, 15);
+        d->callClientSimple<StopRequest>(this, STOP_CALL_ID, [](auto &) {}, 15, true, false);
 
     // stop the module thread first
     AbstractModule::stop();


### PR DESCRIPTION
A change similar to 056e335851ce66617b1f83a761758da492725501.

Why: If my Python Module raises an exception during `prepare()` and afterwards I try to save the settings it fails:

```bash
17:15:54.809839 syntalos:board.save: Saving board as: /home/victor/utm/emc/emc_ilab_daq/boards/arduino_led.syct
17:15:54.816597 syntalos:main: Current board settings file: /home/victor/utm/emc/emc_ilab_daq/boards/arduino_led.syct
17:15:56.759218 syntalos:engine: Storing temporary data in: /var/tmp/syntalos-tmprun-xKrJUb
17:15:56.759220 syntalos:engine: Initializing new ephemeral recording run
17:15:56.775160 syntalos:engine: Explicit CPU core affinity is disabled.
17:15:56.775255 syntalos:engine: Module start order: LED Controller
17:15:56.775255 syntalos:engine: Module stop order:  LED Controller
17:15:56.785184 syntalos:engine: Obtained system sleep/idle/shutdown inhibitor for this run.
17:15:56.785189 syntalos:engine: Predicted amount of CPU cores with no (explicitly known) occupation: 6
17:15:56.785307 syntalos:engine: Preparing 'LED Controller'...
17:15:56.800828 syntalos:mod.arduino_led-0: Error raised by 'LED Controller': RuntimeError: Some dummy error
17:15:56.800828 syntalos:mod.arduino_led-0: 
17:15:56.800828 syntalos:mod.arduino_led-0: At:
17:15:56.800828 syntalos:mod.arduino_led-0:   /home/victor/.local/share/Syntalos/modules/arduino_led/mod-main.py(104): prepare
17:15:56.800828 syntalos:mod.arduino_led-0:   /home/victor/.local/share/Syntalos/modules/arduino_led/mod-main.py(268): main
17:15:56.800828 syntalos:mod.arduino_led-0:   /home/victor/.local/share/Syntalos/modules/arduino_led/mod-main.py(273): <module>
17:15:59.665032 syntalos:engine: Module 'LED Controller' failed to prepare.
17:15:59.668430 syntalos:engine: Run stopped, finalizing...
17:15:59.669472 syntalos:engine: Waited 0 msec for event threads to stop.
17:15:59.669473 syntalos:engine: Stopping 'LED Controller'...
17:15:59.670493 syntalos:engine: Module 'LED Controller' stopped in 0 msec
17:15:59.670494 syntalos:engine: Stopping IPC stream exporter...
17:15:59.670964 syntalos:engine: Joining remaining threads.
17:15:59.671226 syntalos:engine: All (non-event) engine threads joined in 0 msec
17:15:59.671227 syntalos:engine: Removing broken data...
17:15:59.681118 syntalos:engine: Ready.
17:15:59.681255 syntalos:engine: Removing temporary storage directory
17:15:59.681320 syntalos:engine: Ephemeral run completed (result: success)
17:16:04.829994 syntalos:board.save: Saving board as: /home/victor/utm/emc/emc_ilab_daq/boards/arduino_led.syct
17:16:04.832673 syntalos:mod.arduino_led-0: Failed to save settings (issue communicating with the module). Reusing old settings.
17:16:04.832964 syntalos:mod.arduino_led-0: 0 [W] Receiver { connections: PolymorphicVec<iceoryx2_bb_concurrency::cell::UnsafeCell<core::option::Option<iceoryx2_bb_container::slotmap::SlotMapKey>>, iceoryx2_bb_memory::heap_allocator::HeapAllocator> { capacity: 2, len: 2 content: [ UnsafeCell(UnsafeCell { .. }), UnsafeCell(UnsafeCell { .. }) ] }, receiver_port_id: 3104346086804211321435731933221, service_state: ServiceState { dynamic_storage: Storage { shm: SharedMemory { name: FileName { value: StaticString<255> { len: 92, data: "sy_305ad9523c6b202364d581359ec3d2c5743e42e7_cb35bc73827b8835ad85a8e8aa4b6cd1d15cfec1.dynamic" } }, has_ownership: AtomicBool(false), memory_mapping: MemoryMapping { file_descriptor: Some(FileDescriptor { value: 99, is_owned: true }), file_path: None, base_address: 0xffff9c5ef000, size: 747, offset: 0 }, memory_lock: None, mapping_offset: 0 }, name: FileName { value: StaticString<255> { len: 40, data: "cb35bc73827b8835ad85a8e8aa4b6cd1d15cfec1" } }, _phantom_data: PhantomData<iceoryx2::service::dynamic_config::DynamicConfig> }, additional_resource: NoResource, static_config: StaticConfig { service_hash: ServiceHash(RestrictedFileName { value: StaticString<64> { len: 40, data: "cb35bc73827b8835ad85a8e8aa4b6cd1d15cfec1" } }), service_name: ServiceName { value: StaticString<255> { len: 29, data: "Sy/arduino_led_0/SaveSettings" } }, unique_service_id: UniqueServiceId(UniqueSystemId { value: 3025116134162561838846170511397, pid: 669733, creation_time: Time { clock_type: Monotonic, seconds: 52245, nanoseconds: 783116986 } }), attributes: AttributeSet(StaticVec<iceoryx2::service::attribute::Attribute, 8> { len: 0, content: [  ] }), messaging_pattern: RequestResponse(StaticConfig { enable_safe_overflow_for_requests: true, enable_safe_overflow_for_responses: true, enable_fire_and_forget_requests: true, max_active_requests_per_client: 4, max_loaned_requests: 2, max_response_buffer_size: 2, max_servers: 2, max_clients: 2, max_nodes: 4, max_borrowed_responses_per_pending_response: 2, request_message_type_details: MessageTypeDetails { header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 58, data: "iceoryx2::service::header::request_response::RequestHeader" }, size: 56, alignment: 8 }, user_header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 2, data: "()" }, size: 0, alignment: 1 }, payload: TypeDetail { variant: Dynamic, type_name: StaticString<256> { len: 19, data: "__cxx__abi__St4byte" }, size: 1, alignment: 1 } }, response_message_type_details: MessageTypeDetails { header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 59, data: "iceoryx2::service::header::request_response::ResponseHeader" }, size: 48, alignment: 8 }, user_header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 2, data: "()" }, size: 0, alignment: 1 }, payload: TypeDetail { variant: Dynamic, type_name: StaticString<256> { len: 19, data: "__cxx__abi__St4byte" }, size: 1, alignment: 1 } } }) }, shared_node: SharedNode { id: UniqueNodeId(UniqueSystemId { value: 13922977192892559638781376549, pid: 669733, creation_time: Time { clock_type: Monotonic, seconds: 52245, nanoseconds: 754766106 } }), details: NodeDetails { executable: FileName { value: StaticString<255> { len: 10, data: "python3.13" } }, name: NodeName { value: StaticString<128> { len: 13, data: "arduino_led_0" } }, config: Config { global: Global { root_path: Path { value: StaticString<255> { len: 27, data: "/run/user/1000/syntalos-iox" } }, prefix: FileName { value: StaticString<255> { len: 3, data: "sy_" } }, service: Service { directory: Path { value: StaticString<255> { len: 8, data: "services" } }, data_segment_suffix: FileName { value: StaticString<255> { len: 5, data: ".data" } }, static_config_storage_suffix: FileName { value: StaticString<255> { len: 8, data: ".service" } }, dynamic_config_storage_suffix: FileName { value: StaticString<255> { len: 8, data: ".dynamic" } }, creation_timeout: 500ms, connection_suffix: FileName { value: StaticString<255> { len: 11, data: ".connection" } }, event_connection_suffix: FileName { value: StaticString<255> { len: 6, data: ".event" } }, blackboard_mgmt_suffix: FileName { value: StaticString<255> { len: 16, data: ".blackboard_mgmt" } }, blackboard_data_suffix: FileName { value: StaticString<255> { len: 16, data: ".blackboard_data" } } }, node: Node { directory: Path { value: StaticString<255> { len: 5, data: "nodes" } }, monitor_suffix: FileName { value: StaticString<255> { len: 13, data: ".node_monitor" } }, static_config_suffix: FileName { value: StaticString<255> { len: 8, data: ".details" } }, service_tag_suffix: FileName { value: StaticString<255> { len: 12, data: ".service_tag" } }, cleanup_dead_nodes_on_creation: true, cleanup_dead_nodes_on_destruction: true } }, defaults: Defaults { publish_subscribe: PublishSubscribe { max_subscribers: 8, max_publishers: 2, max_nodes: 20, subscriber_max_buffer_size: 2, subscriber_max_borrowed_samples: 2, publisher_max_loaned_samples: 2, publisher_history_size: 0, enable_safe_overflow: true, unable_to_deliver_strategy: Block, subscriber_expired_connection_buffer: 128 }, event: Event { max_listeners: 16, max_notifiers: 16, max_nodes: 36, event_id_max_value: 255, deadline: None, notifier_created_event: None, notifier_dropped_event: None, notifier_dead_event: None }, request_response: RequestResonse { enable_safe_overflow_for_requests: true, enable_safe_overflow_for_responses: true, max_active_requests_per_client: 4, max_response_buffer_size: 2, max_servers: 2, max_clients: 8, max_nodes: 20, max_borrowed_responses_per_pending_response: 2, max_loaned_requests: 2, server_max_loaned_responses_per_request: 2, client_unable_to_deliver_strategy: Block, server_unable_to_deliver_strategy: Block, client_expired_connection_buffer: 128, enable_fire_and_forget_requests: true, server_expired_connection_buffer: 128 }, blackboard: Blackboard { max_readers: 8, max_nodes: 20 } } } }, monitoring_token: UnsafeCell(UnsafeCell { .. }), registered_services: RegisteredServices { handle: MutexHandle { handle: HandleStorage<libc::unix::linux_like::linux::pthread_mutex_t> { is_interprocess_capable: false, is_initialized: true }, clock_type: UnsafeCell(UnsafeCell { .. }), value: UnsafeCell(UnsafeCell { .. }) } }, signal_handling_mode: HandleTerminationRequests, _details_storage: Storage { name: FileName { value: StaticString<255> { len: 4, data: "node" } }, config: Configuration { path: Path { value: StaticString<255> { len: 63, data: "/run/user/1000/syntalos-iox/nodes/13922977192892559638781376549" } }, suffix: FileName { value: StaticString<255> { len: 8, data: ".details" } }, prefix: FileName { value: StaticString<255> { len: 3, data: "sy_" } } }, has_ownership: AtomicBool(false), file: File { path: Some(FilePath { value: StaticString<255> { len: 79, data: "/run/user/1000/syntalos-iox/nodes/13922977192892559638781376549/sy_node.details" } }), file_descriptor: FileDescriptor { value: 18, is_owned: true }, access_mode: ReadWrite, has_ownership: AtomicBool(false) }, len: 1777 } }, static_storage: Storage { name: FileName { value: StaticString<255> { len: 40, data: "cb35bc73827b8835ad85a8e8aa4b6cd1d15cfec1" } }, config: Configuration { path: Path { value: StaticString<255> { len: 36, data: "/run/user/1000/syntalos-iox/services" } }, suffix: FileName { value: StaticString<255> { len: 8, data: ".service" } }, prefix: FileName { value: StaticString<255> { len: 3, data: "sy_" } } }, has_ownership: AtomicBool(false), file: File { path: Some(FilePath { value: StaticString<255> { len: 88, data: "/run/user/1000/syntalos-iox/services/sy_cb35bc73827b8835ad85a8e8aa4b6cd1d15cfec1.service" } }), file_descriptor: FileDescriptor { value: 98, is_owned: true }, access_mode: ReadWrite, has_ownership: AtomicBool(false) }, len: 1519 } }, buffer_size: 4, tagger: CyclicTagger(4), to_be_removed_connections: Some(UnsafeCell(UnsafeCell { .. })), degradation_callback: None, message_type_details: MessageTypeDetails { header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 58, data: "iceoryx2::service::header::request_response::RequestHeader" }, size: 56, alignment: 8 }, user_header: TypeDetail { variant: FixedSize, type_name: StaticString<256> { len: 2, data: "()" }, size: 0, alignment: 1 }, payload: TypeDetail { variant: Dynamic, type_name: StaticString<256> { len: 19, data: "__cxx__abi__St4byte" }, size: 1, alignment: 1 } }, receiver_max_borrowed_samples: 4, enable_safe_overflow: true, number_of_channels: 1, connection_storage: UnsafeCell(UnsafeCell { .. }), initial_channel_state: ChannelState(0) } 
17:16:04.832964 syntalos:mod.arduino_led-0: | Lost a sample. This only happens in the dynamic use case when a sender has reallocated its data segment and gone out of scope before the receiver has mapped the realloacted data segment. To circumvent this, you could either use static memory or increase the initial max slice len.
```

idk if this is the right solution... Codex was suggesting more crazy fixes (that did not work) while this one was a side note.

With this patch the module returns back to `Idle` instead of remaining in `Error` state. It kind of makes sense, it is ready to try again etc.. But not sure what the intention is. Before this patch the module remained red 🤷🏼‍♂️ 

---

btw, is there supposed to be a difference between how syntalos treats Python modules sending a `syl.raise_error(msg)` vs an actual (unhandled) `Exception` being raised in Python? The latter is more handy because the traceback gets nicely printed in red in `syntalos` output