### PR TITLE
mlink: Bypass master queues for direct MLink streams

### DIFF
--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -645,6 +645,11 @@ ModuleDriverKind MLinkModule::driver() const
     return ModuleDriverKind::THREAD_DEDICATED;
 }
 
+bool MLinkModule::usesDirectModuleLink() const
+{
+    return true;
+}
+
 ModuleFeatures MLinkModule::features() const
 {
     return ModuleFeature::SHOW_DISPLAY | ModuleFeature::SHOW_SETTINGS;
@@ -1077,7 +1082,7 @@ bool MLinkModule::registerOutPortForwarders()
 
     // connect to external process streams
     for (auto &oport : outPorts()) {
-        if (!oport->streamVar()->hasSubscribers())
+        if (!oport->streamVar()->hasDataSubscribers())
             continue;
 
         Private::OutPortSub ps;

--- a/src/fabric/mlinkmodule.h
+++ b/src/fabric/mlinkmodule.h
@@ -59,6 +59,7 @@ public:
     bool initialize() override;
 
     ModuleDriverKind driver() const override;
+    bool usesDirectModuleLink() const override;
     virtual ModuleFeatures features() const override;
 
     QString moduleBinary() const;

--- a/src/fabric/moduleapi.cpp
+++ b/src/fabric/moduleapi.cpp
@@ -276,6 +276,12 @@ void VarStreamInputPort::setSubscription(StreamOutputPort *src, std::shared_ptr<
     d->outPort = src;
     m_sub = sub;
 
+    if (sub != nullptr) {
+        const bool useDirectIpc =
+            src != nullptr && src->owner()->usesDirectModuleLink() && d->owner->usesDirectModuleLink();
+        sub->setDirectIpcBypass(useDirectIpc);
+    }
+
     d->owner->inputPortConnected(this);
 
     // signal interested parties as the input module that new
@@ -653,6 +659,11 @@ void AbstractModule::setName(const QString &name)
 ModuleDriverKind AbstractModule::driver() const
 {
     return ModuleDriverKind::NONE;
+}
+
+bool AbstractModule::usesDirectModuleLink() const
+{
+    return false;
 }
 
 ModuleFeatures AbstractModule::features() const

--- a/src/fabric/moduleapi.h
+++ b/src/fabric/moduleapi.h
@@ -508,6 +508,11 @@ public:
     virtual ModuleDriverKind driver() const;
 
     /**
+     * @brief Whether this module can directly exchange stream data over the module-link IPC layer.
+     */
+    virtual bool usesDirectModuleLink() const;
+
+    /**
      * @brief Return a bitfield of features this module supports.
      */
     virtual ModuleFeatures features() const;

--- a/src/fabric/streamexporter.cpp
+++ b/src/fabric/streamexporter.cpp
@@ -24,7 +24,6 @@
 
 #include "streams/stream.h"
 #include "utils/misc.h"
-#include "mlinkmodule.h"
 #include "mlink/ipc-types-private.h"
 #include "mlink/ipc-iox-private.h"
 #include "mlink/syntaloslink.h"
@@ -133,9 +132,11 @@ auto StreamExporter::publishStreamByPort(const std::shared_ptr<VarStreamInputPor
     result.instanceId = modId;
     result.channelId = channelId;
 
-    // if the emitter is an MLink module, the stream is already exported, and we just return its expected info
-    if (dynamic_cast<MLinkModule *>(iport->outPort()->owner()) != nullptr)
+    // If the emitter can publish over direct module-link IPC, the stream is already exported.
+    if (iport->outPort()->owner()->usesDirectModuleLink() && iport->owner()->usesDirectModuleLink()) {
+        iport->subscriptionVar()->setDirectIpcBypass(true);
         return result;
+    }
 
     // If this exact stream is already being exported, the IPC publisher is already
     // set up and IOX takes care of fan-out to multiple IPC subscribers.

--- a/src/fabric/streams/stream.h
+++ b/src/fabric/streams/stream.h
@@ -84,6 +84,8 @@ public:
     virtual int enableNotify() = 0;
     virtual void disableNotify() = 0;
     virtual void setThrottleItemsPerSec(uint itemsPerSec, bool allowMore = true) = 0;
+    virtual void setDirectIpcBypass(bool enabled) = 0;
+    virtual bool isDirectIpcBypass() const = 0;
 
     virtual void suspend() = 0;
     virtual void resume() = 0;
@@ -110,6 +112,8 @@ public:
     [[nodiscard]] virtual bool isActive() const = 0;
     [[nodiscard]] virtual bool hasSubscribers() const = 0;
     [[nodiscard]] virtual size_t subscriberCount() const = 0;
+    [[nodiscard]] virtual bool hasDataSubscribers() const = 0;
+    [[nodiscard]] virtual size_t dataSubscriberCount() const = 0;
     virtual void pushRawData(int typeId, const void *data, size_t size) = 0;
     virtual MetaStringMap metadata() = 0;
     virtual void setMetadata(const MetaStringMap &metadata) = 0;
@@ -146,6 +150,7 @@ public:
           m_notify(false),
           m_active(true),
           m_suspended(false),
+          m_directIpcBypass(false),
           m_throttle(0),
           m_skippedElements(0),
           m_log(getLogger("subscription"))
@@ -381,6 +386,18 @@ public:
         m_skippedElements = 0;
     }
 
+    void setDirectIpcBypass(bool enabled) override
+    {
+        m_directIpcBypass = enabled;
+        if (enabled)
+            clearPending();
+    }
+
+    bool isDirectIpcBypass() const override
+    {
+        return m_directIpcBypass;
+    }
+
     void forcePushNullopt() override
     {
         m_queue.emplace(std::nullopt);
@@ -393,6 +410,7 @@ private:
     std::atomic_bool m_notify;
     std::atomic_bool m_active;
     std::atomic_bool m_suspended;
+    std::atomic_bool m_directIpcBypass;
     std::atomic_uint m_throttle;
     std::atomic_uint m_skippedElements;
 
@@ -415,6 +433,8 @@ private:
     void pushImpl(U &&data)
     {
         // don't accept any new data if we are suspended
+        if (m_directIpcBypass)
+            return;
         if (m_suspended)
             return;
 
@@ -451,6 +471,8 @@ private:
      */
     void push(const T &data)
     {
+        if (m_directIpcBypass || m_suspended)
+            return;
         pushImpl(data.clone());
     }
 
@@ -462,6 +484,8 @@ private:
      */
     void push(T &&data)
     {
+        if (m_directIpcBypass || m_suspended)
+            return;
         pushImpl(std::move(data));
     }
 
@@ -734,6 +758,21 @@ public:
     [[nodiscard]] size_t subscriberCount() const override
     {
         return m_subs.size();
+    }
+
+    [[nodiscard]] bool hasDataSubscribers() const override
+    {
+        return dataSubscriberCount() > 0;
+    }
+
+    [[nodiscard]] size_t dataSubscriberCount() const override
+    {
+        size_t count = 0;
+        for (const auto &sub : m_subs) {
+            if (!sub->isDirectIpcBypass())
+                count++;
+        }
+        return count;
     }
 
 private:


### PR DESCRIPTION
Codex-implemented

> Added direct-IPC capability API via usesDirectModuleLink() in moduleapi.h (line 513), defaulting false, with MLinkModule overriding true in mlinkmodule.cpp (line 648).
>
> Marked MLink-to-MLink graph subscriptions as direct IPC bypass at connection time in moduleapi.cpp (line 274).
>
> Added bypass handling to stream subscriptions so bypassed subscriptions clear pending data and do not enqueue/clone incoming frames in stream.h (line 389).
>
> Added hasDataSubscribers() / dataSubscriberCount() so Syntalos can distinguish real in-process consumers from direct IPC consumers in stream.h (line 763).
> 
> Changed MLink output forwarding so the master process does not subscribe to a worker output when all downstream consumers are direct MLink modules in mlinkmodule.cpp (line 1085).
> 
> Updated StreamExporter direct-IPC fast path to use the new capability API and mark the subscription bypassed in streamexporter.cpp (line 135).

Seems to fix #138