### PR TITLE
aravis: Restore auto-gain and auto-exposure from hardware settings

### DIFF
--- a/modules/camera-arv/configwindow.cpp
+++ b/modules/camera-arv/configwindow.cpp
@@ -202,8 +202,25 @@ void ArvConfigWindow::readAllValues()
     exposureSpinbox->setRange(exposurerange.first / 1000., exposurerange.second / 1000.);
     readGain();
     readExposure();
-    gainAutoButton->setEnabled(camera->hasAutoGain());
-    exposureAutoButton->setEnabled(camera->hasAutoExposure());
+
+    const auto updateAutoButton = [](QPushButton *button, bool available, bool checked) {
+        const bool blocked = button->blockSignals(true);
+        button->setEnabled(available);
+        button->setChecked(checked);
+        button->blockSignals(blocked);
+    };
+
+    const bool autoGainAvailable = camera->hasAutoGain();
+    const bool autoGainEnabled = autoGainAvailable && camera->getAutoGain();
+    updateAutoButton(gainAutoButton, autoGainAvailable, autoGainEnabled);
+    gainSlider->setEnabled(!autoGainEnabled);
+    gainSpinbox->setEnabled(!autoGainEnabled);
+
+    const bool autoExposureAvailable = camera->hasAutoExposure();
+    const bool autoExposureEnabled = autoExposureAvailable && camera->getAutoExposure();
+    updateAutoButton(exposureAutoButton, autoExposureAvailable, autoExposureEnabled);
+    exposureSlider->setEnabled(!autoExposureEnabled);
+    exposureSpinbox->setEnabled(!autoExposureEnabled);
 
     readROILimits();
     QRect roi = camera->getROI();

--- a/modules/camera-arv/qarv/qarvcamera.cpp
+++ b/modules/camera-arv/qarv/qarvcamera.cpp
@@ -330,6 +330,10 @@ bool QArvCamera::hasAutoExposure() {
     return arv_camera_is_exposure_auto_available(camera, nullptr);
 }
 
+bool QArvCamera::getAutoExposure() {
+    return arv_camera_get_exposure_time_auto(camera, nullptr) != ARV_AUTO_OFF;
+}
+
 void QArvCamera::setAutoExposure(bool enable) {
     auto mode = enable ? ARV_AUTO_CONTINUOUS : ARV_AUTO_OFF;
     arv_camera_set_exposure_time_auto(camera, mode, nullptr);
@@ -359,6 +363,10 @@ QPair< double, double > QArvCamera::getGainBounds() {
 
 bool QArvCamera::hasAutoGain() {
     return arv_camera_is_gain_auto_available(camera, nullptr);
+}
+
+bool QArvCamera::getAutoGain() {
+    return arv_camera_get_gain_auto(camera, nullptr) != ARV_AUTO_OFF;
 }
 
 void QArvCamera::setAutoGain(bool enable) {

--- a/modules/camera-arv/qarv/qarvcamera.h
+++ b/modules/camera-arv/qarv/qarvcamera.h
@@ -180,6 +180,7 @@ public:
     void setExposure(double exposure);
     QPair<double, double> getExposureBounds();
     bool hasAutoExposure();
+    bool getAutoExposure();
     void setAutoExposure(bool enable);
     /**@}*/
 
@@ -189,6 +190,7 @@ public:
     void setGain(double gain);
     QPair<double, double> getGainBounds();
     bool hasAutoGain();
+    bool getAutoGain();
     void setAutoGain(bool enable);
     /**@}*/
 


### PR DESCRIPTION
This ensure the GUI stays in sync with the Camera's hardware settings when loading a board.

Before this PR I set the Gain to Auto, saved board, loaded board, the GUI showed the Auto Gain was disabled but when running the board my Camera was clearly auto-adjusting the Gain.

---

For my Basler restoring the Auto Exposure does not seem to work but at least the GUI seems to stay in sync with the underlying setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera now exposes auto-exposure and auto-gain state so UI can reflect current automatic modes.
* **Bug Fixes**
  * Improved synchronization between auto toggles and their dependent controls so settings stay consistent.
  * Refreshed camera state after restoring settings so formats and ROI apply correctly.
  * Clearer handling and reporting of partial failures when loading advanced settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntalos/syntalos/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->