### PR TITLE
Aravis: Restore image transform and propagate rotated output to size metadata

### DIFF
--- a/modules/camera-arv/araviscameramodule.cpp
+++ b/modules/camera-arv/araviscameramodule.cpp
@@ -119,8 +119,9 @@ public:
         m_tfParams = m_configWindow->currentTransformParams();
 
         const auto roi = m_camera->getROI();
-        m_expectedWidth = roi.width();
-        m_expectedHeight = roi.height();
+        const bool swapsAxes = m_tfParams->rot == 1 || m_tfParams->rot == 3;
+        m_expectedWidth = swapsAxes ? roi.height() : roi.width();
+        m_expectedHeight = swapsAxes ? roi.width() : roi.height();
 
         // set the required stream metadata for video capture
         m_outStream->setMetadataValue("size", MetaSize(m_expectedWidth, m_expectedHeight));

--- a/modules/camera-arv/configwindow.cpp
+++ b/modules/camera-arv/configwindow.cpp
@@ -888,6 +888,7 @@ void ArvConfigWindow::loadSettings(const QVariantHash &settings, const QByteArra
             }
         }
     }
+    updateImageTransform();
 
     // ensure any timers run to update the list of available cameras or modify settings
     QApplication::processEvents();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Camera output size now correctly reflects rotation-aware width/height adjustments so reported image dimensions match rotated ROI.
  * Restored camera settings now trigger recalculation of image transform so ROI and pixel-format updates are applied consistently after loading preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntalos/syntalos/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->