### PR TITLE
camera-generic: Bug fixes and warnings on failures

### DIFF
--- a/modules/camera-generic/camera.cpp
+++ b/modules/camera-generic/camera.cpp
@@ -19,7 +19,9 @@
 
 #include "camera.h"
 
+#include <array>
 #include <QFileInfo>
+#include <cmath>
 #include <fcntl.h>
 #include <libv4l2.h>
 #include <linux/videodev2.h>
@@ -27,6 +29,46 @@
 #include <opencv2/videoio.hpp>
 #include <sys/ioctl.h>
 #include "datactl/frametype.h"
+
+struct CameraPropertyInfo
+{
+    int id;
+    const char *name;
+};
+
+static QString cameraPropertyName(int propertyId)
+{
+    static const std::array<CameraPropertyInfo, 11> propertyNames = {{
+        {cv::CAP_PROP_FRAME_WIDTH, "frame width"},
+        {cv::CAP_PROP_FRAME_HEIGHT, "frame height"},
+        {cv::CAP_PROP_FPS, "framerate"},
+        {cv::CAP_PROP_EXPOSURE, "exposure"},
+        {cv::CAP_PROP_BRIGHTNESS, "brightness"},
+        {cv::CAP_PROP_CONTRAST, "contrast"},
+        {cv::CAP_PROP_SATURATION, "saturation"},
+        {cv::CAP_PROP_HUE, "hue"},
+        {cv::CAP_PROP_GAIN, "gain"},
+        {cv::CAP_PROP_AUTO_EXPOSURE, "auto exposure"},
+        {cv::CAP_PROP_FOURCC, "pixel format"},
+    }};
+
+    for (const auto &property : propertyNames) {
+        if (property.id == propertyId)
+            return QString::fromUtf8(property.name);
+    }
+
+    return QStringLiteral("OpenCV property %1").arg(propertyId);
+}
+
+static bool isPositiveFinite(double value)
+{
+    return std::isfinite(value) && value > 0.0;
+}
+
+static bool differsFromRequested(double reported, double requested, double tolerance = 0.5)
+{
+    return !std::isfinite(reported) || std::abs(reported - requested) >= tolerance;
+}
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpadded"
@@ -46,7 +88,9 @@ public:
     cv::VideoCapture *cam{};
     int camId;
 
-    int fps{};
+    // Fractional rates exist, e.g. V4L2: `Interval: Discrete 0.133s (7.500 fps)`
+    double fps{};
+    double activeFps{};
     cv::Size frameSize;
     CameraPixelFormat captureFormat;
 
@@ -77,6 +121,7 @@ Camera::Camera(QuillLogger *logger)
     // set some default values
     d->frameSize = cv::Size(960, 720);
     d->fps = 30;
+    d->activeFps = d->fps;
     d->exposure = 10;
     d->brightness = 0;
     d->contrast = 0;
@@ -111,6 +156,56 @@ void Camera::fail(const QString &msg)
     d->lastError = msg;
 }
 
+std::expected<double, QString> Camera::setCameraProperty(int propertyId, double value, bool check, double tolerance)
+{
+    if (!d->cam || !d->cam->isOpened())
+        return std::unexpected(QStringLiteral("Camera is not open."));
+
+    const auto name = cameraPropertyName(propertyId);
+    if (!d->cam->set(propertyId, value)) {
+        const auto cameraValue = d->cam->get(propertyId);
+        const auto msg = QStringLiteral(
+                             "Failed to set camera property '%1' to %2. Camera reports %3. "
+                             "For more OpenCV video I/O details, run Syntalos with: "
+                             "OPENCV_LOG_LEVEL=DEBUG OPENCV_VIDEOIO_DEBUG=1")
+                             .arg(name)
+                             .arg(value)
+                             .arg(cameraValue);
+        LOG_WARNING(
+            d->log,
+            "{}",
+            msg);
+        return std::unexpected(msg);
+    }
+
+    const auto reportedValue = d->cam->get(propertyId);
+    if (check)
+        warnIfCameraReportsDifferent(propertyId, value, reportedValue, tolerance);
+
+    return reportedValue;
+}
+
+void Camera::warnIfCameraReportsDifferent(
+    int propertyId,
+    double requestedValue,
+    double reportedValue,
+    double tolerance) const
+{
+    if (!d->cam || !d->cam->isOpened())
+        return;
+    if (!differsFromRequested(reportedValue, requestedValue, tolerance))
+        return;
+
+    const auto name = cameraPropertyName(propertyId);
+    LOG_WARNING(
+        d->log,
+        "Requested camera property '{}' value {}, but the backend reports {}. "
+        "Keeping the requested value for future connection attempts.",
+        name,
+        requestedValue,
+        reportedValue);
+}
+
 void Camera::setCamId(int id)
 {
     d->camId = id;
@@ -129,22 +224,47 @@ void Camera::setStartTime(const symaster_timepoint &time)
 void Camera::setResolution(const cv::Size &size)
 {
     d->frameSize = size;
-    d->cam->set(cv::CAP_PROP_FRAME_WIDTH, d->frameSize.width);
-    d->cam->set(cv::CAP_PROP_FRAME_HEIGHT, d->frameSize.height);
+
+    const double requestedWidth = d->frameSize.width;
+    const double requestedHeight = d->frameSize.height;
+    const auto reportedWidth = setCameraProperty(cv::CAP_PROP_FRAME_WIDTH, requestedWidth, false);
+    const auto reportedHeight = setCameraProperty(cv::CAP_PROP_FRAME_HEIGHT, requestedHeight, false);
+    const auto backendReportsDifferentResolution =
+        (reportedWidth && differsFromRequested(*reportedWidth, requestedWidth)) ||
+        (reportedHeight && differsFromRequested(*reportedHeight, requestedHeight));
+
+    if (d->cam && d->cam->isOpened() && backendReportsDifferentResolution) {
+        const auto reportedWidthValue = reportedWidth ? *reportedWidth : requestedWidth;
+        const auto reportedHeightValue = reportedHeight ? *reportedHeight : requestedHeight;
+        LOG_WARNING(
+            d->log,
+            "Requested camera output resolution {}x{}, but the backend reports capture resolution {}x{}. "
+            "Captured frames will be scaled to the requested output resolution.",
+            requestedWidth,
+            requestedHeight,
+            reportedWidthValue,
+            reportedHeightValue);
+    }
 }
 
-int Camera::framerate() const
+double Camera::framerate() const
 {
-    const int capFps = d->cam->get(cv::CAP_PROP_FPS);
-    if (capFps <= 0)
-        return d->fps;
-    return capFps;
+    return isPositiveFinite(d->activeFps) ? d->activeFps : d->fps;
 }
 
-void Camera::setFramerate(int fps)
+void Camera::setFramerate(double fps)
 {
     d->fps = fps;
-    d->cam->set(cv::CAP_PROP_FPS, d->fps);
+    d->activeFps = d->fps;
+
+    const auto reportedFps = setCameraProperty(cv::CAP_PROP_FPS, d->fps, true, 0.5);
+    if (reportedFps && isPositiveFinite(*reportedFps)) {
+        d->activeFps = *reportedFps;
+    } else if (d->cam && d->cam->isOpened()) {
+        const auto currentFps = d->cam->get(cv::CAP_PROP_FPS);
+        if (isPositiveFinite(currentFps))
+            d->activeFps = currentFps;
+    }
 }
 
 cv::Size Camera::resolution() const
@@ -165,7 +285,7 @@ void Camera::setExposure(double value)
         value = 2047;
 
     d->exposure = value;
-    d->cam->set(cv::CAP_PROP_EXPOSURE, value);
+    setCameraProperty(cv::CAP_PROP_EXPOSURE, value);
 }
 
 double Camera::brightness() const
@@ -181,7 +301,7 @@ void Camera::setBrightness(double value)
         value = -100;
 
     d->brightness = value;
-    d->cam->set(cv::CAP_PROP_BRIGHTNESS, value);
+    setCameraProperty(cv::CAP_PROP_BRIGHTNESS, value);
 }
 
 double Camera::contrast() const
@@ -197,7 +317,7 @@ void Camera::setContrast(double value)
         value = 255;
 
     d->contrast = value;
-    d->cam->set(cv::CAP_PROP_CONTRAST, value);
+    setCameraProperty(cv::CAP_PROP_CONTRAST, value);
 }
 
 double Camera::saturation() const
@@ -211,7 +331,7 @@ void Camera::setSaturation(double value)
         value = 255;
 
     d->saturation = value;
-    d->cam->set(cv::CAP_PROP_SATURATION, value);
+    setCameraProperty(cv::CAP_PROP_SATURATION, value);
 }
 
 double Camera::hue() const
@@ -227,7 +347,7 @@ void Camera::setHue(double value)
         value = -100;
 
     d->hue = value;
-    d->cam->set(cv::CAP_PROP_HUE, value);
+    setCameraProperty(cv::CAP_PROP_HUE, value);
 }
 
 double Camera::gain() const
@@ -241,7 +361,7 @@ void Camera::setGain(double value)
         value = 255;
 
     d->gain = value;
-    d->cam->set(cv::CAP_PROP_GAIN, value);
+    setCameraProperty(cv::CAP_PROP_GAIN, value);
 }
 
 int Camera::autoExposureRaw() const
@@ -252,6 +372,7 @@ int Camera::autoExposureRaw() const
 void Camera::setAutoExposureRaw(int value)
 {
     d->autoExposureRaw = value;
+    setCameraProperty(cv::CAP_PROP_AUTO_EXPOSURE, d->autoExposureRaw, true, 0.5);
 }
 
 bool Camera::connect()
@@ -281,23 +402,30 @@ bool Camera::connect()
         LOG_INFO(d->log, "Unable to use preferred camera backend for {} falling back to autodetection.", d->camId);
         ret = d->cam->open(d->camId);
     }
+    if (!ret) {
+        const auto msg = QStringLiteral("Unable to open camera %1.").arg(d->camId);
+        LOG_ERROR(d->log, "{}", msg);
+        fail(msg);
+        return false;
+    }
 
-    d->cam->set(cv::CAP_PROP_FPS, d->fps);
-    d->cam->set(cv::CAP_PROP_AUTO_EXPOSURE, d->autoExposureRaw);
+    d->failed = false;
+    d->lastError.clear();
 
     // set initial defaults
     setPixelFormat(d->captureFormat);
+    setFramerate(d->fps);
+    setAutoExposureRaw(d->autoExposureRaw);
     setExposure(d->exposure);
     setBrightness(d->brightness);
     setContrast(d->contrast);
     setSaturation(d->saturation);
     setHue(d->hue);
+    setGain(d->gain);
 
-    d->cam->set(cv::CAP_PROP_FRAME_WIDTH, d->frameSize.width);
-    d->cam->set(cv::CAP_PROP_FRAME_HEIGHT, d->frameSize.height);
+    setResolution(d->frameSize);
 
     // we are connected now
-    d->failed = false;
     d->connected = true;
 
     // temporary dummy timepoint, until the actual reference starting
@@ -314,6 +442,7 @@ void Camera::disconnect()
     if (d->connected)
         LOG_INFO(d->log, "Disconnected camera {}", d->camId);
     d->connected = false;
+    d->activeFps = d->fps;
 }
 
 QList<CameraPixelFormat> Camera::readPixelFormats()
@@ -348,8 +477,21 @@ void Camera::setPixelFormat(const CameraPixelFormat &pixFmt)
         return;
 
     LOG_INFO(d->log, "Setting pixel format to: {}", pixFmt.fourcc);
-    d->cam->set(cv::CAP_PROP_FOURCC, pixFmt.fourcc);
     d->captureFormat = pixFmt;
+
+    const auto actualFourcc = setCameraProperty(cv::CAP_PROP_FOURCC, pixFmt.fourcc, false);
+    const auto backendReportsDifferentFormat =
+        actualFourcc && (!isPositiveFinite(*actualFourcc) || std::round(*actualFourcc) != pixFmt.fourcc);
+
+    if (d->cam && d->cam->isOpened() && backendReportsDifferentFormat) {
+        LOG_WARNING(
+            d->log,
+            "Requested camera pixel format '{}' ({}), but the backend reports {}. "
+            "Keeping the selected pixel format for future connection attempts.",
+            pixFmt.name,
+            pixFmt.fourcc,
+            *actualFourcc);
+    }
 }
 
 bool Camera::recordFrame(Frame &frame, SecondaryClockSynchronizer *clockSync)

--- a/modules/camera-generic/camera.h
+++ b/modules/camera-generic/camera.h
@@ -21,6 +21,7 @@
 #define GENERIC_CAMERA_H
 
 #include <QSize>
+#include <expected>
 #include <opencv2/core.hpp>
 
 #include "logging.h"
@@ -64,8 +65,8 @@ public:
     cv::Size resolution() const;
     void setResolution(const cv::Size &size);
 
-    int framerate() const;
-    void setFramerate(int fps);
+    double framerate() const;
+    void setFramerate(double fps);
 
     double exposure() const;
     void setExposure(double value);
@@ -104,6 +105,13 @@ private:
     std::unique_ptr<CameraData> d;
 
     void fail(const QString &msg);
+    std::expected<double, QString> setCameraProperty(
+        int propertyId,
+        double value,
+        bool check = true,
+        // Camera backends might quantize hardware properties before reporting them back.
+        double tolerance = 0.5);
+    void warnIfCameraReportsDifferent(int propertyId, double requestedValue, double reportedValue, double tolerance) const;
 };
 
 #endif // GENERIC_CAMERA_H

--- a/modules/camera-generic/genericcameramodule.cpp
+++ b/modules/camera-generic/genericcameramodule.cpp
@@ -24,6 +24,8 @@
 #include "camera.h"
 #include "genericcamerasettingsdialog.h"
 
+#include <cmath>
+
 SYNTALOS_MODULE(GenericCameraModule)
 
 class GenericCameraModule : public AbstractModule
@@ -89,16 +91,41 @@ public:
             return false;
         }
 
+        constexpr auto fpsTolerance = 0.5;
+        const auto requestedFps = m_camSettingsWindow->framerate();
+        if (!std::isfinite(requestedFps) || requestedFps <= 0) {
+            raiseError(QStringLiteral("Unable to continue: Invalid camera framerate %1fps requested.").arg(requestedFps));
+            return false;
+        }
+
         statusMessage("Connecting camera...");
         m_camera->setResolution(m_camSettingsWindow->resolution());
         if (!m_camera->connect()) {
             raiseError(QStringLiteral("Unable to connect camera: %1").arg(m_camera->lastError()));
             return false;
         }
+        m_camera->setFramerate(requestedFps);
+
+        const auto actualFps = m_camera->framerate();
+        auto effectiveFps = actualFps;
+        if (!std::isfinite(actualFps) || actualFps <= 0) {
+            LOG_ERROR(
+                m_log,
+                "Camera backend reported invalid framerate {}fps. Using requested {}fps.",
+                actualFps,
+                requestedFps);
+            effectiveFps = requestedFps;
+        } else if (std::isfinite(actualFps) && actualFps > 0 && std::abs(actualFps - requestedFps) >= fpsTolerance) {
+            LOG_ERROR(
+                m_log,
+                "Requested camera framerate {}fps, but the backend reports {}fps. Using backend-reported framerate.",
+                requestedFps,
+                actualFps);
+            effectiveFps = actualFps;
+        }
 
         m_camSettingsWindow->setRunning(true);
-        m_fps = m_camSettingsWindow->framerate();
-        m_camera->setFramerate(m_fps);
+        m_fps = effectiveFps;
 
         // set the required stream metadata for video capture
         m_outStream->setMetadataValue("size", MetaSize(m_camera->resolution().width, m_camera->resolution().height));
@@ -220,7 +247,7 @@ public:
         m_camera->setSaturation(settings.value("saturation").toDouble());
         m_camera->setHue(settings.value("hue").toDouble());
         m_camera->setGain(settings.value("gain").toDouble());
-        m_camSettingsWindow->setFramerate(settings.value("fps").toInt());
+        m_camSettingsWindow->setFramerate(settings.value("fps").toDouble());
 
         auto quirks = settings.value("quirks").toHash();
         bool haveQuirks = quirks.value("enabled", false).toBool();

--- a/modules/camera-generic/genericcamerasettingsdialog.cpp
+++ b/modules/camera-generic/genericcamerasettingsdialog.cpp
@@ -53,12 +53,12 @@ cv::Size GenericCameraSettingsDialog::resolution() const
     return cv::Size(ui->spinBoxWidth->value(), ui->spinBoxHeight->value());
 }
 
-int GenericCameraSettingsDialog::framerate() const
+double GenericCameraSettingsDialog::framerate() const
 {
     return ui->fpsSpinBox->value();
 }
 
-void GenericCameraSettingsDialog::setFramerate(int fps)
+void GenericCameraSettingsDialog::setFramerate(double fps)
 {
     ui->fpsSpinBox->setValue(fps);
 }

--- a/modules/camera-generic/genericcamerasettingsdialog.h
+++ b/modules/camera-generic/genericcamerasettingsdialog.h
@@ -39,8 +39,8 @@ public:
     QVariant selectedCamera() const;
     cv::Size resolution() const;
 
-    int framerate() const;
-    void setFramerate(int fps);
+    double framerate() const;
+    void setFramerate(double fps);
 
     bool quirksEnabled();
     void setQuirksEnabled(bool enabled);

--- a/modules/camera-generic/genericcamerasettingsdialog.ui
+++ b/modules/camera-generic/genericcamerasettingsdialog.ui
@@ -169,18 +169,24 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QSpinBox" name="fpsSpinBox">
+         <widget class="QDoubleSpinBox" name="fpsSpinBox">
           <property name="toolTip">
            <string>Frames per second</string>
           </property>
+          <property name="decimals">
+           <number>3</number>
+          </property>
           <property name="minimum">
-           <number>4</number>
+           <double>4.000000000000000</double>
           </property>
           <property name="maximum">
-           <number>30</number>
+           <double>480.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
           </property>
           <property name="value">
-           <number>20</number>
+           <double>20.000000000000000</double>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This is mostly Codex implemented. Main issue was that the gain was not being set and setting settings would pass by silently (made them emit warnings).

Maybe these improvements are useful to others.

Feel free to close this if it is too many changes. I played a bit with one of the camera and it seemed to work ok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized camera property handling with backend-verified application and tolerance-based mismatch warnings
  * Framerate now supports and reports fractional (floating-point) values end-to-end

* **Bug Fixes**
  * Fail-fast behavior and clearer diagnostics when camera connection fails
  * Warnings when device-reported properties (resolution, pixel format, tuning) differ from requested values

* **Improvements**
  * UI and settings persist FPS as a floating-point value for finer configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntalos/syntalos/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->