### PR TITLE
camera-lc: Log getFrame timeout

### DIFF
--- a/modules/camera-lc/lccamera.cpp
+++ b/modules/camera-lc/lccamera.cpp
@@ -924,6 +924,10 @@ bool LcCamera::getFrame(Frame &frame, SecondaryClockSynchronizer *clockSync)
                 return !d->completedQueue.empty() || d->stopping;
             })) {
             // timed out waiting for a frame
+            if (d->log)
+                LOG_WARNING(
+                    d->log,
+                    "Timed out after 5 seconds waiting for a completed camera request; no libcamera requestCompleted callback was received.");
             return false;
         }
         if (d->stopping || d->completedQueue.empty())


### PR DESCRIPTION
A 5s timeout is worth logging. It helps to spot the issue I mentioned https://github.com/syntalos/syntalos/issues/163#issuecomment-4679924934

Additionally you might want to consider handling this a bit differently because if this timeout repeats itself, it makes no sense to way till it happens 32 times before actually raising an error 😅 (i know this module is recent and for now it has mainly generic error handling)