### PR TITLE
python: Add set_status_message function

### DIFF
--- a/src/fabric/mlinkmodule.cpp
+++ b/src/fabric/mlinkmodule.cpp
@@ -87,6 +87,7 @@ public:
     // Subscribers to receive information from module processes
     std::optional<IoxSubscriber<ErrorEvent>> subError;
     std::optional<IoxSubscriber<StateChangeEvent>> subStateChange;
+    std::optional<IoxSubscriber<StatusMessageEvent>> subStatusMsg;
     std::optional<IoxSubscriber<SyncDetailsEvent>> subSyncDetails;
     std::optional<IoxSubscriber<SyncOffsetEvent>> subSyncOffset;
     std::optional<IoxUntypedReqServer> srvInPortChange;
@@ -152,6 +153,19 @@ public:
                 self->raiseError(msg);
             else
                 self->raiseError(QStringLiteral("<html><b>%1</b><br/>%2").arg(title, msg));
+        }
+    }
+
+    void checkClientStatusMessage(MLinkModule *self)
+    {
+        if (!subStatusMsg.has_value())
+            return;
+
+        while (true) {
+            auto sample = safeReceive(*subStatusMsg);
+            if (!sample.has_value())
+                break;
+            self->setStatusMessage(QString::fromUtf8(sample->payload().text.unchecked_access().c_str()));
         }
     }
 
@@ -613,6 +627,9 @@ void MLinkModule::handleIncomingControl()
     // State changes
     d->checkClientStateChange(this);
 
+    // Status messages
+    d->checkClientStatusMessage(this);
+
     // Synchronizer notifications
     d->checkClientSyncDetails(this);
     d->checkClientSyncOffset(this);
@@ -786,6 +803,7 @@ void MLinkModule::resetConnection()
     // ensure the old connections are gone before we are trying to create new ones
     d->subError.reset();
     d->subStateChange.reset();
+    d->subStatusMsg.reset();
     d->subSyncDetails.reset();
     d->subSyncOffset.reset();
     d->srvInPortChange.reset();
@@ -797,6 +815,7 @@ void MLinkModule::resetConnection()
     // (re)create subscribers/servers for client -> master data channels
     d->subError.emplace(makeTypedSubscriber<ErrorEvent>(*d->node, d->svcName(ERROR_CHANNEL_ID)));
     d->subStateChange.emplace(makeTypedSubscriber<StateChangeEvent>(*d->node, d->svcName(STATE_CHANNEL_ID)));
+    d->subStatusMsg.emplace(makeTypedSubscriber<StatusMessageEvent>(*d->node, d->svcName(STATUS_MESSAGE_CHANNEL_ID)));
     d->subSyncDetails.emplace(makeTypedSubscriber<SyncDetailsEvent>(*d->node, d->svcName(SYNC_DETAILS_CHANNEL_ID)));
     d->subSyncOffset.emplace(makeTypedSubscriber<SyncOffsetEvent>(*d->node, d->svcName(SYNC_OFFSET_CHANNEL_ID)));
     d->srvInPortChange.emplace(makeSliceServer(*d->node, d->svcName(IN_PORT_CHANGE_CHANNEL_ID)));

--- a/src/python/pysy-mlink.cpp
+++ b/src/python/pysy-mlink.cpp
@@ -596,6 +596,11 @@ public:
         m_slink->setState(ModuleState::IDLE);
     }
 
+    void setStatusMessage(const std::optional<std::string> &message)
+    {
+        m_slink->setStatusMessage(message.value_or(std::string()));
+    }
+
     /**
      * Returns true if the experiment is currently running.
      */
@@ -1798,6 +1803,17 @@ PYBIND11_MODULE(syntalos_mlink, m)
             "Signal IDLE (initialization complete) without entering the built-in event loop.\n"
             "\n"
             "Call this before starting a custom loop with :meth:`await_data`.")
+        .def(
+            "set_status_message",
+            &PySyLinkManager::setStatusMessage,
+            py::arg("message") = py::none(),
+            "Set the GUI-visible module status message.\n"
+            "\n"
+            "May contain limited HTML rich text if it starts with '<html>' and must be as short as possible.\n"
+            "Long messages will be truncated.\n"
+            "Pass ``None`` or an empty string to clear it.\n"
+            "\n"
+            ":param message: Human-readable status message.")
 
         // ---- EDL storage access ----
 


### PR DESCRIPTION
I have a few use cases in which I would like to have control over the status message.

This is Codex-implemented draft, I hope it is clean and simple enough.

Idk if it makes more sense to be a method on the SyntalosLink object or on the global `syntalos_mlink`. The current implementation follows the `syntalos_mlink.raise_error` pattern.