### PR TITLE
videorecorder: Fix VP9 lossless encoding

### DIFF
--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -825,6 +825,7 @@ void VideoWriter::initializeInternal()
             // This codec is lossless by default
             break;
         case VideoCodec::VP9:
+            av_dict_set_int(&codecopts, "crf", 0, 0);
             av_dict_set_int(&codecopts, "lossless", 1, 0);
             break;
         case VideoCodec::H264:
@@ -855,7 +856,7 @@ void VideoWriter::initializeInternal()
         // for more information on the settings.
 
         d->cctx->gop_size = 90;
-        if (d->codecProps.mode() == CodecProperties::ConstantBitrate) {
+        if (!d->codecProps.isLossless() && d->codecProps.mode() == CodecProperties::ConstantBitrate) {
             d->cctx->qmin = 4;
             d->cctx->qmax = 48;
             av_dict_set_int(&codecopts, "crf", 24, 0);


### PR DESCRIPTION
To encode in lossless mode CRF must be 0, otherwise it fails with invalid arguments.

```
13:27:12.908643 I syntalos:engine: Running...
[libvpx-vp9 @ 0x7f2ab8460400] v1.15.0
[libvpx-vp9 @ 0x7f2ab8460400] CQ level 24 must be between minimum and maximum quantizer value (0-0)
13:27:12.918413 E videorecorde-9:mod.videorecorder-2:
Error raised by 'Recorder Top Side':
Unable to initialize recording: Failed to open video encoder with the current parameters:
Invalid argument
```