### PR TITLE
videowriter: Fix AV1 VAAPI

### DIFF
--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -443,7 +443,6 @@ public:
 
         hwDevCtx = nullptr;
         hwFrameCtx = nullptr;
-        hwFrame = nullptr;
 
         selectedEncoderName = QStringLiteral("No encoder selected yet");
     }
@@ -488,7 +487,6 @@ public:
 
     AVBufferRef *hwDevCtx;
     AVBufferRef *hwFrameCtx;
-    AVFrame *hwFrame;
 };
 #pragma GCC diagnostic pop
 
@@ -590,6 +588,8 @@ void VideoWriter::initializeHWAccell()
     ctx->height = d->height;
     ctx->format = cst->valid_hw_formats[0];
     ctx->sw_format = AV_PIX_FMT_NV12;
+    // Delayed hardware encoders may retain frame references after avcodec_send_frame().
+    ctx->initial_pool_size = 16;
 
     if ((ret = av_hwframe_ctx_init(d->hwFrameCtx))) {
         av_hwframe_constraints_free(&cst);
@@ -948,22 +948,6 @@ void VideoWriter::initializeInternal()
     // allocate input buffer for color conversion
     d->inputFrame = vw_alloc_frame(d->inputPixFormat, d->width, d->height, false);
 
-    if (d->hwDevCtx != nullptr) {
-        // setup frame for hardware acceleration
-
-        d->hwFrame = av_frame_alloc();
-        auto frctx = (AVHWFramesContext *)d->hwFrameCtx->data;
-        d->hwFrame->format = frctx->format;
-        d->hwFrame->hw_frames_ctx = av_buffer_ref(d->hwFrameCtx);
-        d->hwFrame->width = d->width;
-        d->hwFrame->height = d->height;
-
-        if (av_hwframe_get_buffer(d->hwFrameCtx, d->hwFrame, 0)) {
-            finalizeInternal(false);
-            throw std::runtime_error("Failed to retrieve HW frame buffer.");
-        }
-    }
-
     // set file metadata
     AVDictionary *metadataDict = nullptr;
     av_dict_set(&metadataDict, "title", qPrintable(d->videoTitle), 0);
@@ -1068,10 +1052,6 @@ std::expected<void, std::string> VideoWriter::finalizeInternal(bool writeTrailer
     if (d->inputFrame != nullptr) {
         av_frame_free(&d->inputFrame);
         d->inputFrame = nullptr;
-    }
-    if (d->hwFrame != nullptr) {
-        av_frame_free(&d->hwFrame);
-        d->hwFrame = nullptr;
     }
 
     if (d->hwDevCtx != nullptr)
@@ -1358,6 +1338,7 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     }
 
     AVBufferRef *savedBuf0 = nullptr;
+    AVFrame *hwFrame = nullptr;
     auto outputFrame = d->encFrame;
 
     const auto tsUsec = timestamp.count();
@@ -1395,13 +1376,28 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
         d->encFrame->buf[0] = nullptr;
     } else {
         // we are GPU accelerated! Copy frame to the GPU.
-        if (av_hwframe_transfer_data(d->hwFrame, d->encFrame, 0)) {
-            d->lastError = QStringLiteral("Failed to upload data to the GPU").toStdString();
+        hwFrame = av_frame_alloc();
+        if (hwFrame == nullptr) {
+            d->lastError = QStringLiteral("Unable to allocate VAAPI video frame.").toStdString();
             std::cerr << d->lastError << std::endl;
             goto out;
         }
-        d->hwFrame->pts = d->encFrame->pts;
-        outputFrame = d->hwFrame;
+
+        ret = av_hwframe_get_buffer(d->hwFrameCtx, hwFrame, 0);
+        if (ret < 0) {
+            d->lastError = std::format("Failed to retrieve VAAPI frame buffer: {}", averrorToString(ret));
+            std::cerr << d->lastError << std::endl;
+            goto out;
+        }
+
+        ret = av_hwframe_transfer_data(hwFrame, d->encFrame, 0);
+        if (ret < 0) {
+            d->lastError = std::format("Failed to upload data to the GPU: {}", averrorToString(ret));
+            std::cerr << d->lastError << std::endl;
+            goto out;
+        }
+        hwFrame->pts = d->encFrame->pts;
+        outputFrame = hwFrame;
     }
 
     // encode video frame
@@ -1455,6 +1451,7 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     success = true;
 out:
     av_packet_free(&pkt);
+    av_frame_free(&hwFrame);
 
     // restore frame buffer, so that it can be properly freed in the end
     if (savedBuf0) {

--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -1345,7 +1345,6 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
 {
     int ret;
     bool success = false;
-    bool havePacket = false;
 
     if (!prepareFrame(frame)) {
         std::cerr << "Unable to prepare frame. N: " << d->framesN + 1 << "(" << d->lastError << ")" << std::endl;
@@ -1363,6 +1362,33 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
 
     const auto tsUsec = timestamp.count();
 
+    auto receivePackets = [&]() -> bool {
+        while (true) {
+            ret = avcodec_receive_packet(d->cctx, pkt);
+            if (ret == AVERROR(EAGAIN))
+                return true;
+            if (ret < 0) {
+                d->lastError = std::format("Unable to receive packet from encoder: {}", averrorToString(ret));
+                std::cerr << d->lastError << std::endl;
+                return false;
+            }
+
+            // rescale packet timestamp
+            pkt->duration = 1;
+            av_packet_rescale_ts(pkt, d->cctx->time_base, d->vstrm->time_base);
+
+            // write packet
+            ret = av_write_frame(d->octx, pkt);
+            if (ret < 0) {
+                d->lastError = std::format("Unable to write frame packet to output: {}", averrorToString(ret));
+                std::cerr << d->lastError << std::endl;
+                return false;
+            }
+
+            av_packet_unref(pkt);
+        }
+    };
+
     if (d->hwDevCtx == nullptr) {
         // force FFmpeg to create a copy of the frame, if the codec needs it
         savedBuf0 = d->encFrame->buf[0];
@@ -1379,42 +1405,22 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     }
 
     // encode video frame
-    ret = avcodec_send_frame(d->cctx, outputFrame);
-    if (ret < 0) {
-        d->lastError = QStringLiteral("Unable to send frame to encoder. N: %1").arg(d->framesN + 1).toStdString();
-        std::cerr << d->lastError << std::endl;
-        goto out;
-    }
-
-    ret = avcodec_receive_packet(d->cctx, pkt);
-    if (ret != 0) {
+    while (true) {
+        ret = avcodec_send_frame(d->cctx, outputFrame);
         if (ret == AVERROR(EAGAIN)) {
-            // Some encoders need to be fed a few frames before they produce a packet, but the
-            // frames are still saved. So we encounter for that fact.
-            havePacket = false;
-        } else {
-            // we have a real error and can not continue
-            d->lastError = std::format("Unable to send packet to codec: {}", averrorToString(ret));
-            std::cerr << d->lastError << std::endl;
-            goto out;
+            if (!receivePackets())
+                goto out;
+            continue;
         }
-    } else {
-        havePacket = true;
-    }
-
-    if (havePacket) {
-        // rescale packet timestamp
-        pkt->duration = 1;
-        av_packet_rescale_ts(pkt, d->cctx->time_base, d->vstrm->time_base);
-
-        // write packet
-        ret = av_write_frame(d->octx, pkt);
         if (ret < 0) {
-            d->lastError = std::format("Unable to write frame packet to output: {}", averrorToString(ret));
+            d->lastError = std::format("Unable to send frame {} to encoder: {}.", d->framesN + 1, averrorToString(ret));
             std::cerr << d->lastError << std::endl;
             goto out;
         }
+        break;
     }
+    if (!receivePackets())
+        goto out;
 
     // store timestamp (if necessary)
     if (d->saveTimestamps) {

--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -1443,7 +1443,6 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
 {
     int ret;
     bool success = false;
-    bool havePacket = false;
 
     if (!prepareFrame(frame)) {
         std::cerr << "Unable to prepare frame. N: " << d->framesN + 1 << "(" << d->lastError << ")" << std::endl;
@@ -1461,6 +1460,33 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
 
     const auto tsUsec = timestamp.count();
 
+    auto receivePackets = [&]() -> bool {
+        while (true) {
+            ret = avcodec_receive_packet(d->cctx, pkt);
+            if (ret == AVERROR(EAGAIN))
+                return true;
+            if (ret < 0) {
+                d->lastError = std::format("Unable to receive packet from encoder: {}", averrorToString(ret));
+                std::cerr << d->lastError << std::endl;
+                return false;
+            }
+
+            // rescale packet timestamp
+            pkt->duration = 1;
+            av_packet_rescale_ts(pkt, d->cctx->time_base, d->vstrm->time_base);
+
+            // write packet
+            ret = av_write_frame(d->octx, pkt);
+            if (ret < 0) {
+                d->lastError = std::format("Unable to write frame packet to output: {}", averrorToString(ret));
+                std::cerr << d->lastError << std::endl;
+                return false;
+            }
+
+            av_packet_unref(pkt);
+        }
+    };
+
     if (d->hwDevCtx == nullptr) {
         // force FFmpeg to create a copy of the frame, if the codec needs it
         savedBuf0 = d->encFrame->buf[0];
@@ -1477,42 +1503,22 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     }
 
     // encode video frame
-    ret = avcodec_send_frame(d->cctx, outputFrame);
-    if (ret < 0) {
-        d->lastError = QStringLiteral("Unable to send frame to encoder. N: %1").arg(d->framesN + 1).toStdString();
-        std::cerr << d->lastError << std::endl;
-        goto out;
-    }
-
-    ret = avcodec_receive_packet(d->cctx, pkt);
-    if (ret != 0) {
+    while (true) {
+        ret = avcodec_send_frame(d->cctx, outputFrame);
         if (ret == AVERROR(EAGAIN)) {
-            // Some encoders need to be fed a few frames before they produce a packet, but the
-            // frames are still saved. So we encounter for that fact.
-            havePacket = false;
-        } else {
-            // we have a real error and can not continue
-            d->lastError = std::format("Unable to send packet to codec: {}", averrorToString(ret));
-            std::cerr << d->lastError << std::endl;
-            goto out;
+            if (!receivePackets())
+                goto out;
+            continue;
         }
-    } else {
-        havePacket = true;
-    }
-
-    if (havePacket) {
-        // rescale packet timestamp
-        pkt->duration = 1;
-        av_packet_rescale_ts(pkt, d->cctx->time_base, d->vstrm->time_base);
-
-        // write packet
-        ret = av_write_frame(d->octx, pkt);
         if (ret < 0) {
-            d->lastError = std::format("Unable to write frame packet to output: {}", averrorToString(ret));
+            d->lastError = std::format("Unable to send frame {} to encoder: {}.", d->framesN + 1, averrorToString(ret));
             std::cerr << d->lastError << std::endl;
             goto out;
         }
+        break;
     }
+    if (!receivePackets())
+        goto out;
 
     // store timestamp (if necessary)
     if (d->saveTimestamps) {

--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -443,7 +443,6 @@ public:
 
         hwDevCtx = nullptr;
         hwFrameCtx = nullptr;
-        hwFrame = nullptr;
 
         selectedEncoderName = QStringLiteral("No encoder selected yet");
     }
@@ -488,7 +487,6 @@ public:
 
     AVBufferRef *hwDevCtx;
     AVBufferRef *hwFrameCtx;
-    AVFrame *hwFrame;
 };
 #pragma GCC diagnostic pop
 
@@ -590,6 +588,8 @@ void VideoWriter::initializeHWAccell()
     ctx->height = d->height;
     ctx->format = cst->valid_hw_formats[0];
     ctx->sw_format = AV_PIX_FMT_NV12;
+    // Delayed hardware encoders may retain frame references after avcodec_send_frame().
+    ctx->initial_pool_size = 16;
 
     if ((ret = av_hwframe_ctx_init(d->hwFrameCtx))) {
         av_hwframe_constraints_free(&cst);
@@ -1046,22 +1046,6 @@ void VideoWriter::initializeInternal()
     // allocate input buffer for color conversion
     d->inputFrame = vw_alloc_frame(d->inputPixFormat, d->width, d->height, false);
 
-    if (d->hwDevCtx != nullptr) {
-        // setup frame for hardware acceleration
-
-        d->hwFrame = av_frame_alloc();
-        auto frctx = (AVHWFramesContext *)d->hwFrameCtx->data;
-        d->hwFrame->format = frctx->format;
-        d->hwFrame->hw_frames_ctx = av_buffer_ref(d->hwFrameCtx);
-        d->hwFrame->width = d->width;
-        d->hwFrame->height = d->height;
-
-        if (av_hwframe_get_buffer(d->hwFrameCtx, d->hwFrame, 0)) {
-            finalizeInternal(false);
-            throw std::runtime_error("Failed to retrieve HW frame buffer.");
-        }
-    }
-
     // set file metadata
     AVDictionary *metadataDict = nullptr;
     av_dict_set(&metadataDict, "title", qPrintable(d->videoTitle), 0);
@@ -1166,10 +1150,6 @@ std::expected<void, std::string> VideoWriter::finalizeInternal(bool writeTrailer
     if (d->inputFrame != nullptr) {
         av_frame_free(&d->inputFrame);
         d->inputFrame = nullptr;
-    }
-    if (d->hwFrame != nullptr) {
-        av_frame_free(&d->hwFrame);
-        d->hwFrame = nullptr;
     }
 
     if (d->hwDevCtx != nullptr)
@@ -1456,6 +1436,7 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     }
 
     AVBufferRef *savedBuf0 = nullptr;
+    AVFrame *hwFrame = nullptr;
     auto outputFrame = d->encFrame;
 
     const auto tsUsec = timestamp.count();
@@ -1493,13 +1474,28 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
         d->encFrame->buf[0] = nullptr;
     } else {
         // we are GPU accelerated! Copy frame to the GPU.
-        if (av_hwframe_transfer_data(d->hwFrame, d->encFrame, 0)) {
-            d->lastError = QStringLiteral("Failed to upload data to the GPU").toStdString();
+        hwFrame = av_frame_alloc();
+        if (hwFrame == nullptr) {
+            d->lastError = QStringLiteral("Unable to allocate VAAPI video frame.").toStdString();
             std::cerr << d->lastError << std::endl;
             goto out;
         }
-        d->hwFrame->pts = d->encFrame->pts;
-        outputFrame = d->hwFrame;
+
+        ret = av_hwframe_get_buffer(d->hwFrameCtx, hwFrame, 0);
+        if (ret < 0) {
+            d->lastError = std::format("Failed to retrieve VAAPI frame buffer: {}", averrorToString(ret));
+            std::cerr << d->lastError << std::endl;
+            goto out;
+        }
+
+        ret = av_hwframe_transfer_data(hwFrame, d->encFrame, 0);
+        if (ret < 0) {
+            d->lastError = std::format("Failed to upload data to the GPU: {}", averrorToString(ret));
+            std::cerr << d->lastError << std::endl;
+            goto out;
+        }
+        hwFrame->pts = d->encFrame->pts;
+        outputFrame = hwFrame;
     }
 
     // encode video frame
@@ -1553,6 +1549,7 @@ bool VideoWriter::encodeFrame(const cv::Mat &frame, const std::chrono::microseco
     success = true;
 out:
     av_packet_free(&pkt);
+    av_frame_free(&hwFrame);
 
     // restore frame buffer, so that it can be properly freed in the end
     if (savedBuf0) {


### PR DESCRIPTION
before this fix:

```
19:40:35.607890 E videorecorde-1:mod.videorecorder-0: Error raised by 'Video Recorder':
Unable to send frame 1 to encoder: Resource temporarily unavailable.
```

(Error code message already fixed via #184)

Codex says:

> this points to  an encoder-loop bug, Syntalos is not following FFmpeg’s send/receive backpressure contract:
> Syntalos calls avcodec_send_frame().
> If that returns EAGAIN, Syntalos currently treats it as fatal.
> Correct behavior is: call avcodec_receive_packet() in a loop until it returns EAGAIN, write any packets, then retry avcodec_send_frame() with the same frame.

I have no idea if Codex is right or not, but it indeed solved the issue, AV1 via VAAPI seems to work. I did not yet look at an actual recording contents to double check it looks good.