### PR TITLE
videowriter: Prevent silently ignoring AV1 unused codec options

### DIFF
--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -918,6 +918,21 @@ void VideoWriter::initializeInternal()
         throw std::runtime_error(
             std::format("Failed to open video encoder with the current parameters: {}", averrorToString(ret)));
     }
+    if (codecopts != nullptr) {
+        const AVDictionaryEntry *entry = nullptr;
+        std::string unusedCodecOpts;
+        while ((entry = av_dict_get(codecopts, "", entry, AV_DICT_IGNORE_SUFFIX)) != nullptr) {
+            if (!unusedCodecOpts.empty())
+                unusedCodecOpts += ", ";
+            unusedCodecOpts += entry->key;
+            unusedCodecOpts += "=";
+            unusedCodecOpts += entry->value;
+        }
+        if (!unusedCodecOpts.empty())
+            LOG_WARNING(d->log, "Video encoder ignored codec option(s): {}", unusedCodecOpts);
+
+        av_dict_free(&codecopts);
+    }
 
     // stream codec parameters must be set after opening the encoder
     avcodec_parameters_from_context(d->vstrm->codecpar, d->cctx);


### PR DESCRIPTION
lossless=1 has been silently ignored in AV1 and created the confusion I mentioned in https://github.com/syntalos/syntalos-web/pull/14

this patch does not fix that, but at least yields a warning about unused AV1 encoder options

for software encoding AV1 ignores `lossless=1` and for hardware encoding `crf=`:

```
22:38:55.517082 W videorecorde-1:mod.videorecorder-0: Video encoder ignored codec option(s): lossless=1
22:38:55.519881 W videorecorde-2:mod.videorecorder-1: Video encoder ignored codec option(s): crf=63
```

idk if lossless being ignored is due to the libraries on my machine or if it generally not available and should be simply disabled (or if it requires some other parameter e.g. `qp=0`)