### PR TITLE
trivial: Install missing libraries to fix crash collector not opening

### DIFF
--- a/tools/crashreport/meson.build
+++ b/tools/crashreport/meson.build
@@ -52,5 +52,6 @@ executable('syntalos-crashreport',
     include_directories: [root_include_dir,
                           include_directories('../../src')],
     install_dir: get_option('libexecdir'),
+    install_rpath: sy_libdir,
     install: true
 )


### PR DESCRIPTION
libsyntalos-fabric.so was not being installed during `ninja install`. Opening the crash collector requires it.

I run into this while trying to debug #193, sadly after this fix it could not read the dumps either, see #194 