### PR TITLE
camera-arv: Increase frame queue size for slow FPS

### DIFF
--- a/modules/camera-arv/araviscameramodule.cpp
+++ b/modules/camera-arv/araviscameramodule.cpp
@@ -145,8 +145,8 @@ public:
         g_autoptr(GMainLoop) loop = g_main_loop_new(nullptr, FALSE);
         const auto expectedFps = m_camera->getFPS();
 
-        // we carry one second of data or 15 frames in the queue
-        m_camera->setFrameQueueSize(expectedFps > 15 ? static_cast<uint>(std::ceil(expectedFps)) + 1 : 15);
+        // we carry one second of data or 30 frames in the queue
+        m_camera->setFrameQueueSize(expectedFps > 30 ? static_cast<uint>(std::ceil(expectedFps)) + 1 : 30);
 
         // set up clock synchronizer
         // Held via shared_ptr (not the unique_ptr returned by initClockSynchronizer) so


### PR DESCRIPTION
I run into an edge case with one of my "older" [aca640-750um Basler](https://docs.baslerweb.com/aca640-750um) cameras.

When

- syntalos board containing only the `camera-arv` and a Canvas
- the CPU is running at close to 100% (due to other tasks on the system, I was running some intrinsic/extrinsic calibration optimizations); and
- the frame rate is set to a slow < ~25 FPS

After an a few minutes, the frame rate drops to 0.0 FPS and never recovers.

Strangely enough I can have 2 additional (newer) [a2a1920-160ucbas Basler](https://docs.baslerweb.com/a2a1920-160ucbas) cameras running on the same board with even higher resolutions and it seems to never affect these cameras. All cameras are on the same USB controller.

After some debugging (with Codex), this was the only thing that seems to solve it (at least under ~30 minutes or so of testing).

Instrumenting the code with more logging revealed that:

> Syntalos currently uses 15 buffers at 10 FPS. Your terminal trace had exactly 15 started-but-not-finished buffers (476 - 461), meaning the complete Syntalos queue was outstanding when streaming froze.

I could not reproduce the problem with `arv-camera-test` which queues 50 frames instead (and for some reason it was not even able to acquire high priority thread and yet did not fail during my 10 FPS test).

30 FPS is enough on my system, maybe worth using a larger queue, e.g., 50.

---

Of course, running heavy loads on the machine while acquiring production data with Syntalos is probably a bad idea... but still in principle it should have been able to handle it I think.

Overall and edge case, but seems relevant to fix.