### PR TITLE
camera-arv: Prevent crashing due to empty QArvEnumeration

### DIFF
--- a/modules/camera-arv/qarv/qarvcamera.cpp
+++ b/modules/camera-arv/qarv/qarvcamera.cpp
@@ -890,11 +890,27 @@ bool QArvCamera::setData(const QModelIndex& index, const QVariant& value,
                             NULL);
     } else if (value.canConvert<QArvEnumeration>()) {
         auto e = qvariant_cast<QArvEnumeration>(value);
+        if (e.currentValue < 0
+            || e.currentValue >= e.values.size()
+            || e.currentValue >= e.isAvailable.size()) {
+            logMessage() << "Unable to set enumeration" << treenode->feature()
+                         << ": invalid selection index" << e.currentValue
+                         << "(values:" << e.values.size()
+                         << ", availability flags:" << e.isAvailable.size() << ")";
+            return false;
+        }
+
         if (e.isAvailable.at(e.currentValue)) {
+            g_autoptr(GError) error = nullptr;
             arv_gc_enumeration_set_string_value(ARV_GC_ENUMERATION(node),
                                                 e.values.at(
                                                     e.currentValue).toLatin1().data(),
-                                                NULL);
+                                                &error);
+            if (error != nullptr) {
+                logMessage() << "Unable to set enumeration" << treenode->feature()
+                             << ":" << error->message;
+                return false;
+            }
         } else return false;
     } else if (value.canConvert<QArvCommand>()) {
         arv_gc_command_execute(ARV_GC_COMMAND(node), NULL);

--- a/modules/camera-arv/qarv/qarvtype.cpp
+++ b/modules/camera-arv/qarv/qarvtype.cpp
@@ -30,7 +30,7 @@ QArvEditor::QArvEditor(QWidget* parent) : QWidget(parent) {
     setAutoFillBackground(true);
 }
 
-QArvEnumeration::QArvEnumeration() : values(), isAvailable() {}
+QArvEnumeration::QArvEnumeration() : values(), isAvailable(), currentValue(-1) {}
 
 QArvEnumeration::operator QString() const {
     return currentValue >= 0 ? names[currentValue] : QString();


### PR DESCRIPTION
See the upstream issue for details
https://github.com/AravisProject/aravis/issues/795#issuecomment-5281101302

The workaround for now is to set `ARV_REGISTER_CACHE_POLICY_DISABLE`, i.e., disable the `Enable camera register cache` checkbox under the Advanced tab of the GUI.

Fixes crashes like these:
[SyntalosCrashReport_261208_basler_GPIO.md](https://github.com/user-attachments/files/31031161/SyntalosCrashReport_261208_basler_GPIO.md)
