### PR TITLE
videorecorder: Preserver FFV1 16 bits pixel format in recordings

### DIFF
--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -893,7 +893,7 @@ void VideoWriter::initializeInternal()
         if (d->inputPixFormat == AV_PIX_FMT_GRAY8)
             d->encPixFormat = AV_PIX_FMT_GRAY8;
         if (d->inputPixFormat == AV_PIX_FMT_GRAY16LE)
-            d->encPixFormat = AV_PIX_FMT_GRAY8;
+            d->encPixFormat = AV_PIX_FMT_GRAY16LE;
         break;
     default:
         break;


### PR DESCRIPTION
@ximion was this a typo? or is this intentional? if intentional it is not really lossless anymore 😅 

I am not using this format so far, Codex spotted it