### PR TITLE
videorecorder: Keep lossless codec settings synchronized

### DIFF
--- a/modules/videorecorder/meson.build
+++ b/modules/videorecorder/meson.build
@@ -44,16 +44,28 @@ module_name = fs.name(meson.current_source_dir()).to_lower().underscorify().repl
 mod_install_dir = join_paths(sy_modules_dir, fs.name(meson.current_source_dir()))
 
 module_moc = []
-if module_moc_hdr.length() != 0 or module_moc_src.length() != 0
-    module_moc += qt.compile_moc(
+module_hdr_moc = []
+module_src_moc = []
+module_ui_moc = []
+if module_moc_hdr.length() != 0
+    module_hdr_moc = qt.compile_moc(
         headers: module_moc_hdr,
+        dependencies: module_deps,
+        extra_args: ['--no-notes'],
+    )
+    module_moc += module_hdr_moc
+endif
+if module_moc_src.length() != 0
+    module_src_moc = qt.compile_moc(
         sources: module_moc_src,
         dependencies: module_deps,
         extra_args: ['--no-notes'],
     )
+    module_moc += module_src_moc
 endif
 if module_ui.length() != 0
-    module_moc += qt.compile_ui(sources: module_ui)
+    module_ui_moc = qt.compile_ui(sources: module_ui)
+    module_moc += module_ui_moc
 endif
 mod = shared_module(module_name,
     [module_hdr, module_moc_hdr,
@@ -85,6 +97,35 @@ install_data(
 foreach fname : module_data
     fs.copyfile(fname)
 endforeach
+
+vrec_settings_test_src = ['recordersettingsdialog-test.cpp']
+vrec_settings_test_moc = qt.compile_moc(sources: vrec_settings_test_src)
+vrec_settings_test_exe = executable(
+    'test-videorecorder-settings',
+    [
+        vrec_settings_test_src,
+        'videowriter.cpp',
+        'recordersettingsdialog.cpp',
+        module_hdr_moc,
+        module_ui_moc,
+        vrec_settings_test_moc,
+    ],
+    dependencies: [
+        syntalos_fabric_dep,
+        module_deps,
+        qt_test_dep,
+    ],
+    cpp_args: module_args,
+)
+vrec_settings_test_env = environment()
+vrec_settings_test_env.set('QT_QPA_PLATFORM', 'offscreen')
+test(
+    'sy-test-videorecorder-settings',
+    vrec_settings_test_exe,
+    env: vrec_settings_test_env,
+    is_parallel: true,
+)
+
 module_hdr = []
 module_src = []
 module_moc_hdr = []

--- a/modules/videorecorder/recordersettingsdialog-test.cpp
+++ b/modules/videorecorder/recordersettingsdialog-test.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Syntalos contributors
+ *
+ * Licensed under the GNU Lesser General Public License Version 3
+ */
+
+#include "recordersettingsdialog.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QtTest>
+
+namespace
+{
+int findCodecIndex(const QComboBox *comboBox, VideoCodec codec)
+{
+    for (int i = 0; i < comboBox->count(); ++i) {
+        if (comboBox->itemData(i).value<VideoCodec>() == codec)
+            return i;
+    }
+    return -1;
+}
+} // namespace
+
+class RecorderSettingsDialogTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        initializeSyLogSystem();
+    }
+
+    void losslessModeIsEnforcedByCodecProperties()
+    {
+        CodecProperties ffv1(VideoCodec::FFV1);
+        ffv1.setLossless(false);
+        QVERIFY(ffv1.isLossless());
+
+        CodecProperties raw(VideoCodec::Raw);
+        raw.setLossless(false);
+        QVERIFY(raw.isLossless());
+
+        CodecProperties mpeg4(VideoCodec::MPEG4);
+        mpeg4.setLossless(true);
+        QVERIFY(!mpeg4.isLossless());
+
+        CodecProperties av1(VideoCodec::AV1);
+        av1.setLossless(true);
+        QVERIFY(av1.isLossless());
+        av1.setLossless(false);
+        QVERIFY(!av1.isLossless());
+    }
+
+    void freshDialogHasSynchronizedFfv1State()
+    {
+        RecorderSettingsDialog dialog;
+        const auto codecComboBox = dialog.findChild<QComboBox *>(QStringLiteral("codecComboBox"));
+        const auto containerComboBox = dialog.findChild<QComboBox *>(QStringLiteral("containerComboBox"));
+        const auto losslessCheckBox = dialog.findChild<QCheckBox *>(QStringLiteral("losslessCheckBox"));
+        const auto losslessLabel = dialog.findChild<QLabel *>(QStringLiteral("losslessLabel"));
+
+        QVERIFY(codecComboBox);
+        QVERIFY(containerComboBox);
+        QVERIFY(losslessCheckBox);
+        QVERIFY(losslessLabel);
+        QVERIFY(codecComboBox->currentData().value<VideoCodec>() == VideoCodec::FFV1);
+        QVERIFY(dialog.codecProps().codec() == VideoCodec::FFV1);
+        QVERIFY(dialog.codecProps().isLossless());
+        QVERIFY(losslessCheckBox->isChecked());
+        QVERIFY(!losslessCheckBox->isEnabled());
+        QVERIFY(!losslessLabel->isEnabled());
+        QVERIFY(!containerComboBox->isEnabled());
+    }
+
+    void codecSwitchKeepsUiAndModelSynchronized()
+    {
+        RecorderSettingsDialog dialog;
+        const auto codecComboBox = dialog.findChild<QComboBox *>(QStringLiteral("codecComboBox"));
+        const auto losslessCheckBox = dialog.findChild<QCheckBox *>(QStringLiteral("losslessCheckBox"));
+
+        QVERIFY(codecComboBox);
+        QVERIFY(losslessCheckBox);
+
+        const int av1Index = findCodecIndex(codecComboBox, VideoCodec::AV1);
+        const int ffv1Index = findCodecIndex(codecComboBox, VideoCodec::FFV1);
+        QVERIFY(av1Index >= 0);
+        QVERIFY(ffv1Index >= 0);
+
+        codecComboBox->setCurrentIndex(av1Index);
+        QVERIFY(dialog.codecProps().codec() == VideoCodec::AV1);
+        QVERIFY(!dialog.codecProps().isLossless());
+        QVERIFY(losslessCheckBox->isEnabled());
+        QVERIFY(!losslessCheckBox->isChecked());
+
+        losslessCheckBox->setChecked(true);
+        QVERIFY(dialog.codecProps().isLossless());
+
+        codecComboBox->setCurrentIndex(ffv1Index);
+        QVERIFY(dialog.codecProps().codec() == VideoCodec::FFV1);
+        QVERIFY(dialog.codecProps().isLossless());
+        QVERIFY(losslessCheckBox->isChecked());
+        QVERIFY(!losslessCheckBox->isEnabled());
+    }
+
+    void inconsistentSavedFfv1StateIsNormalized()
+    {
+        CodecProperties ffv1(VideoCodec::FFV1);
+        auto savedState = ffv1.toVariant();
+        savedState[QStringLiteral("lossless")] = false;
+
+        CodecProperties restored(savedState);
+        QVERIFY(restored.isLossless());
+
+        RecorderSettingsDialog dialog;
+        dialog.setCodecProps(restored);
+        const auto losslessCheckBox = dialog.findChild<QCheckBox *>(QStringLiteral("losslessCheckBox"));
+        QVERIFY(losslessCheckBox);
+        QVERIFY(losslessCheckBox->isChecked());
+        QVERIFY(!losslessCheckBox->isEnabled());
+
+        // Even a programmatic invalid toggle must not corrupt the codec model.
+        losslessCheckBox->setChecked(false);
+        QVERIFY(dialog.codecProps().isLossless());
+        QVERIFY(losslessCheckBox->isChecked());
+    }
+
+    void unavailableVaapiConfigurationIsDisabledInModel()
+    {
+        RecorderSettingsDialog dialog;
+        const auto vaapiCheckBox = dialog.findChild<QCheckBox *>(QStringLiteral("vaapiCheckBox"));
+        QVERIFY(vaapiCheckBox);
+
+        CodecProperties av1(VideoCodec::AV1);
+        av1.setUseVaapi(true);
+        dialog.setCodecProps(av1);
+
+        if (vaapiCheckBox->isEnabled()) {
+            QVERIFY(dialog.codecProps().useVaapi());
+            QVERIFY(vaapiCheckBox->isChecked());
+        } else {
+            QVERIFY(!dialog.codecProps().useVaapi());
+            QVERIFY(!vaapiCheckBox->isChecked());
+        }
+    }
+};
+
+QTEST_MAIN(RecorderSettingsDialogTest)
+#include "recordersettingsdialog-test.moc"

--- a/modules/videorecorder/recordersettingsdialog.cpp
+++ b/modules/videorecorder/recordersettingsdialog.cpp
@@ -21,6 +21,7 @@
 #include "ui_recordersettingsdialog.h"
 
 #include <QMessageBox>
+#include <QSignalBlocker>
 #include <QThread>
 #include <QVariant>
 
@@ -41,13 +42,16 @@ RecorderSettingsDialog::RecorderSettingsDialog(QWidget *parent)
     // Currently FFV1 is the best option for lossless encoding, and VP9 is the best choice
     // for lossy encoding, unless the CPU is capable of encoding AV1 quickly enough
 
-    ui->codecComboBox->addItem("FFV1", QVariant::fromValue(VideoCodec::FFV1));
-    ui->codecComboBox->addItem("AV1", QVariant::fromValue(VideoCodec::AV1));
-    ui->codecComboBox->addItem("VP9", QVariant::fromValue(VideoCodec::VP9));
-    ui->codecComboBox->addItem("HEVC", QVariant::fromValue(VideoCodec::HEVC));
-    ui->codecComboBox->addItem("H.264", QVariant::fromValue(VideoCodec::H264));
-    ui->codecComboBox->addItem("Raw", QVariant::fromValue(VideoCodec::Raw));
-    ui->codecComboBox->setCurrentIndex(0);
+    {
+        const QSignalBlocker blocker(ui->codecComboBox);
+        ui->codecComboBox->addItem("FFV1", QVariant::fromValue(VideoCodec::FFV1));
+        ui->codecComboBox->addItem("AV1", QVariant::fromValue(VideoCodec::AV1));
+        ui->codecComboBox->addItem("VP9", QVariant::fromValue(VideoCodec::VP9));
+        ui->codecComboBox->addItem("HEVC", QVariant::fromValue(VideoCodec::HEVC));
+        ui->codecComboBox->addItem("H.264", QVariant::fromValue(VideoCodec::H264));
+        ui->codecComboBox->addItem("Raw", QVariant::fromValue(VideoCodec::Raw));
+        ui->codecComboBox->setCurrentIndex(0);
+    }
 
     // take name from source module by default
     ui->nameFromSrcCheckBox->setChecked(true);
@@ -73,6 +77,9 @@ RecorderSettingsDialog::RecorderSettingsDialog(QWidget *parent)
     ui->deferredParallelCountSpinBox->setMinimum(1);
     const auto defaultDeferredTasks = QThread::idealThreadCount() - 2;
     ui->deferredParallelCountSpinBox->setValue((defaultDeferredTasks >= 2) ? defaultDeferredTasks : 2);
+
+    // Synchronize the initial widget state after all controls have been populated.
+    setCodecProps(m_codecProps);
 }
 
 RecorderSettingsDialog::~RecorderSettingsDialog()
@@ -120,6 +127,16 @@ void RecorderSettingsDialog::setCodecProps(CodecProperties props)
 {
     m_codecProps = props;
 
+    // This function renders m_codecProps in the UI. Do not let programmatic
+    // widget updates feed back into and partially overwrite that model.
+    const QSignalBlocker codecBlocker(ui->codecComboBox);
+    const QSignalBlocker losslessBlocker(ui->losslessCheckBox);
+    const QSignalBlocker vaapiBlocker(ui->vaapiCheckBox);
+    const QSignalBlocker renderNodeBlocker(ui->renderNodeComboBox);
+    const QSignalBlocker qualityBlocker(ui->qualitySlider);
+    const QSignalBlocker bitrateBlocker(ui->bitrateSpinBox);
+    const QSignalBlocker modeBlocker(ui->radioButtonBitrate);
+
     // select codec in UI
     for (int i = 0; i < ui->codecComboBox->count(); i++) {
         if (ui->codecComboBox->itemData(i).value<VideoCodec>() == props.codec()) {
@@ -144,30 +161,23 @@ void RecorderSettingsDialog::setCodecProps(CodecProperties props)
         ui->containerComboBox->setCurrentIndex(0);
     ui->containerComboBox->setEnabled(m_codecProps.allowsAviContainer());
 
-    // set lossles UI preferences
-    if (m_codecProps.losslessMode() == CodecProperties::Always) {
-        ui->losslessCheckBox->setEnabled(false);
-        ui->losslessCheckBox->setChecked(true);
-    } else if (m_codecProps.losslessMode() == CodecProperties::Never) {
-        ui->losslessCheckBox->setEnabled(false);
-        ui->losslessCheckBox->setChecked(false);
-    } else {
-        ui->losslessCheckBox->setEnabled(true);
-        ui->losslessCheckBox->setChecked(props.isLossless());
-    }
-    ui->losslessLabel->setEnabled(ui->losslessCheckBox->isEnabled());
+    // set lossless UI preferences
+    const bool losslessEditable = m_codecProps.losslessMode() == CodecProperties::Option;
+    ui->losslessCheckBox->setEnabled(losslessEditable);
+    ui->losslessCheckBox->setChecked(m_codecProps.isLossless());
+    ui->losslessLabel->setEnabled(losslessEditable);
 
     // change VAAPI option
-    if (m_renderNodes.isEmpty()) {
-        ui->vaapiCheckBox->setEnabled(false);
-        ui->vaapiLabel->setEnabled(false);
-        ui->renderNodeLabel->setEnabled(false);
-        ui->renderNodeComboBox->setEnabled(false);
-    } else {
-        ui->vaapiCheckBox->setEnabled(m_codecProps.canUseVaapi());
-        ui->vaapiLabel->setEnabled(m_codecProps.canUseVaapi());
-        ui->vaapiCheckBox->setChecked(m_codecProps.canUseVaapi() ? m_codecProps.useVaapi() : false);
-    }
+    const bool canConfigureVaapi = !m_renderNodes.isEmpty() && m_codecProps.canUseVaapi();
+    if (!canConfigureVaapi)
+        m_codecProps.setUseVaapi(false);
+    const bool useVaapi = m_codecProps.useVaapi();
+    ui->vaapiCheckBox->setEnabled(canConfigureVaapi);
+    ui->vaapiLabel->setEnabled(canConfigureVaapi);
+    ui->vaapiCheckBox->setChecked(useVaapi);
+    ui->vaapiCheckBox->setText(useVaapi ? QStringLiteral("(experimental)") : QStringLiteral(" "));
+    ui->renderNodeLabel->setEnabled(useVaapi);
+    ui->renderNodeComboBox->setEnabled(useVaapi);
 
     // update slicing issue hint
     ui->sliceWarnButton->setVisible(false);
@@ -187,14 +197,13 @@ void RecorderSettingsDialog::setCodecProps(CodecProperties props)
         ui->qualitySlider->setValue(m_codecProps.quality());
     }
     ui->bitrateSpinBox->setValue(m_codecProps.bitrateKbps());
-
-    // other properties
-    ui->losslessCheckBox->setChecked(m_codecProps.isLossless());
+    ui->qualityValLabel->setText(QString::number(m_codecProps.quality()));
 
     ui->brqWidget->setDisabled(ui->losslessCheckBox->isChecked());
 
-    ui->radioButtonBitrate->setChecked(m_codecProps.mode() == CodecProperties::ConstantBitrate);
-    on_radioButtonBitrate_toggled(m_codecProps.mode() == CodecProperties::ConstantBitrate);
+    const bool bitrateMode = m_codecProps.mode() == CodecProperties::ConstantBitrate;
+    ui->radioButtonBitrate->setChecked(bitrateMode);
+    ui->qualityValWidget->setEnabled(!bitrateMode);
 
     // change whether deferred encoding is possible
     ui->encodeAfterRunCheckBox->setEnabled(true);
@@ -289,11 +298,6 @@ void RecorderSettingsDialog::on_nameLineEdit_textChanged(const QString &arg1)
 
 void RecorderSettingsDialog::on_codecComboBox_currentIndexChanged(int)
 {
-    // reset state of lossless infobox
-    ui->losslessCheckBox->setEnabled(true);
-    ui->losslessCheckBox->setChecked(true);
-    ui->containerComboBox->setEnabled(true);
-
     const auto codec = ui->codecComboBox->currentData().value<VideoCodec>();
     if (codec == m_codecProps.codec())
         return;
@@ -313,7 +317,12 @@ void RecorderSettingsDialog::on_nameFromSrcCheckBox_toggled(bool checked)
 void RecorderSettingsDialog::on_losslessCheckBox_toggled(bool checked)
 {
     m_codecProps.setLossless(checked);
-    ui->brqWidget->setDisabled(checked);
+    const bool lossless = m_codecProps.isLossless();
+    if (checked != lossless) {
+        const QSignalBlocker blocker(ui->losslessCheckBox);
+        ui->losslessCheckBox->setChecked(lossless);
+    }
+    ui->brqWidget->setDisabled(lossless);
 }
 
 void RecorderSettingsDialog::on_vaapiCheckBox_toggled(bool checked)

--- a/modules/videorecorder/videowriter.cpp
+++ b/modules/videorecorder/videowriter.cpp
@@ -329,7 +329,17 @@ bool CodecProperties::isLossless() const
 
 void CodecProperties::setLossless(bool enabled)
 {
-    d->lossless = enabled;
+    switch (d->losslessMode) {
+    case Always:
+        d->lossless = true;
+        break;
+    case Never:
+        d->lossless = false;
+        break;
+    case Option:
+        d->lossless = enabled;
+        break;
+    }
 }
 
 bool CodecProperties::canUseVaapi() const

--- a/modules/videorecorder/videowriter.h
+++ b/modules/videorecorder/videowriter.h
@@ -109,6 +109,7 @@ public:
 
     LosslessMode losslessMode() const;
     bool isLossless() const;
+    // Always/Never modes enforce their fixed value; only Option accepts enabled.
     void setLossless(bool enabled);
 
     bool canUseVaapi() const;


### PR DESCRIPTION
Synchronize codec widgets after dialog initialization and block feedback signals while applying codec properties.

Enforce fixed lossless states for FFV1, Raw, and MPEG-4, normalize inconsistent saved settings, and add regression tests.

Issue:

E.g. lossless checkbox out of sync after adding module to the board

<img width="559" height="608" alt="Screenshot_20260820_091845" src="https://github.com/user-attachments/assets/ee6be18b-04e1-41a0-b26f-5eacc6988954" />

NB Codex implemented