### PR TITLE
Videotransform even-sized fixes

### DIFF
--- a/modules/videotransform/videotransform.cpp
+++ b/modules/videotransform/videotransform.cpp
@@ -487,19 +487,19 @@ void ScaleTransform::createSettingsUi(QWidget *parent)
 
 MetaSize ScaleTransform::resultSize()
 {
-    return {
-        static_cast<int>(std::round(m_originalSize.width * m_scaleFactor)),
-        static_cast<int>(std::round(m_originalSize.height * m_scaleFactor))};
+    const int width = std::max(2, static_cast<int>(std::round(m_originalSize.width * m_scaleFactor)));
+    const int height = std::max(2, static_cast<int>(std::round(m_originalSize.height * m_scaleFactor)));
+    return {width - width % 2, height - height % 2};
 }
 
 void ScaleTransform::process(cv::Mat &image)
 {
-    // Only process if scale factor is not 1.0 to avoid unnecessary work
-    if (std::abs(m_scaleFactor - 1.0) < 1e-6)
+    const auto size = resultSize();
+    if (image.cols == size.width && image.rows == size.height)
         return;
 
     cv::Mat outMat;
-    cv::resize(image, outMat, cv::Size(), m_scaleFactor, m_scaleFactor, cv::INTER_LINEAR);
+    cv::resize(image, outMat, cv::Size(size.width, size.height), 0, 0, cv::INTER_LINEAR);
     image = outMat;
 }
 

--- a/modules/videotransform/videotransform.cpp
+++ b/modules/videotransform/videotransform.cpp
@@ -402,10 +402,14 @@ void CropTransform::checkAndUpdateRoi()
     // frames with odd dimensions, so never hand a cropped size on that we can not record.
     m_roi.width -= m_roi.width % 2;
     m_roi.height -= m_roi.height % 2;
-    if (m_roi.width < 2)
-        m_roi.width = std::min(2, m_originalSize.width);
-    if (m_roi.height < 2)
-        m_roi.height = std::min(2, m_originalSize.height);
+    if (m_roi.width < 2) {
+        m_roi.x = std::min(m_roi.x, std::max(0, m_originalSize.width - 2));
+        m_roi.width = std::min(2, m_originalSize.width - m_roi.x);
+    }
+    if (m_roi.height < 2) {
+        m_roi.y = std::min(m_roi.y, std::max(0, m_originalSize.height - 2));
+        m_roi.height = std::min(2, m_originalSize.height - m_roi.y);
+    }
 
     // give user some info as to what we are actually doing, if the GUI is set up
     if (m_sizeInfoLabel != nullptr) {


### PR DESCRIPTION
Codex reported issues and fixes:

> **High — even-size crop correction can create an out-of-bounds ROI.**
> After constraining the ROI to the remaining image area, odd sizes are rounded down and values below two are forced back to two syntalos/modules/videotransform/videotransform.cpp:398, 
> syntalos/modules/videotransform/videotransform.cpp:405. The origin is not moved back inside the image.
> For a 640-wide image, x=639,width=1 becomes x=639,width=2. Processing it at syntalos/modules/videotransform/videotransform.cpp:319 throws an OpenCV ROI assertion. This is reachable through saved settings/headless operation and potentially the region selector.

> **Medium — odd-dimension handling is simultaneously too broad and incomplete.**
> The built-in Scale transform still rounds to arbitrary dimensions modules/videotransform/videotransform.cpp:484. Scaling 640×480 by 1.01 produces 646×485 and is rejected by the recorder. The commit’s “stop producing them” intention therefore only covers Crop.

it also says:

> modules/videorecorder/videowriter.cpp:1342 rejects every odd frame before considering the selected codec, pixel format, or whether the video is grayscale. FFV1 successfully encoded both grayscale and exact-color BGR0 at 641×479 in a direct FFmpeg check, so previously valid recordings now fail.

but I never really needed odd sizes, nor I see myself needing them anytime soon.