### PR TITLE
Read frame refcount atomically

### DIFF
--- a/src/datactl/frametype.h
+++ b/src/datactl/frametype.h
@@ -47,8 +47,12 @@ namespace Syntalos
  */
 inline void matEnsureExclusive(cv::Mat &mat, int rows, int cols, int type)
 {
-    const bool canReuse = (mat.data != nullptr) && (mat.u != nullptr && mat.u->refcount == 1) && (mat.rows == rows)
-                          && (mat.cols == cols) && (mat.type() == type);
+    const bool sameLayout = (mat.data != nullptr) && (mat.u != nullptr) && (mat.rows == rows) && (mat.cols == cols)
+                            && (mat.type() == type);
+
+    // OpenCV changes this internal counter through CV_XADD. A zero delta gives us
+    // a compatible atomic read while subscriber threads concurrently release frames.
+    const bool canReuse = sameLayout && (CV_XADD(&mat.u->refcount, 0) == 1);
     if (!canReuse)
         mat = cv::Mat(rows, cols, type);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -22,6 +22,23 @@ test('sy-test-basic',
 )
 
 #
+# Frame Buffer Recycling Test
+#
+test_frame_recycling_exe = executable('test-frame-recycling',
+    'test-frame-recycling.cpp',
+    dependencies: [
+        syntalos_datactl_dep,
+        opencv_dep,
+        thread_dep,
+    ]
+)
+test('sy-test-frame-recycling',
+    test_frame_recycling_exe,
+    env: test_env,
+    is_parallel: true,
+)
+
+#
 # Basic Stream Performance Test
 #
 test_streamperf_moc_src = ['test-streamperf.cpp']

--- a/tests/test-frame-recycling.cpp
+++ b/tests/test-frame-recycling.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the license, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <barrier>
+#include <cstdlib>
+#include <thread>
+
+#include "datactl/frametype.h"
+
+using namespace Syntalos;
+
+namespace
+{
+
+/**
+ * Perform the refcount part of cv::Mat::release() in this translation unit.
+ *
+ * Distribution OpenCV libraries are not normally instrumented by ThreadSanitizer.
+ * Keeping OpenCV's exact CV_XADD operation visible here lets the sanitizer observe
+ * a subscriber releasing its shallow copy concurrently with Syntalos deciding whether
+ * to recycle the producer's buffer.
+ */
+void releaseSubscriber(cv::Mat &subscriber)
+{
+    if (subscriber.u && CV_XADD(&subscriber.u->refcount, -1) == 1)
+        subscriber.deallocate();
+
+    subscriber.u = nullptr;
+    subscriber.datastart = subscriber.dataend = subscriber.datalimit = subscriber.data = nullptr;
+    for (int i = 0; i < subscriber.dims; ++i)
+        subscriber.size.p[i] = 0;
+}
+
+} // namespace
+
+int main()
+{
+    cv::Mat producer(8, 8, CV_8UC1);
+    cv::Mat subscriber = producer;
+    std::barrier startLine(2);
+
+    std::thread subscriberThread([&subscriber, &startLine] {
+        startLine.arrive_and_wait();
+        releaseSubscriber(subscriber);
+    });
+
+    startLine.arrive_and_wait();
+    matEnsureExclusive(producer, producer.rows, producer.cols, producer.type());
+    subscriberThread.join();
+
+    return producer.u != nullptr && producer.u->refcount == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Codex seems to have identified a potential race condition in the recent datactl change.

See the test commit and its message with how it proved it. the other commit implements a solution but might be fragile and dependent on OpenCV internals.

Codex suggests as a long-term solution an explicit Syntalos buffer lease/pool whose slots are returned when the final Frame lease is released.

I understand too little of this, but since it seems to have a test that proves was worth reporting (i hope) 🙂