### PR TITLE
datactl: Keep synchronized timestamps strictly increasing

### DIFF
--- a/src/datactl/timesync.cpp
+++ b/src/datactl/timesync.cpp
@@ -709,8 +709,9 @@ void SecondaryClockSynchronizer::processTimestamp(
             // correct fluke unconditionally
             masterTimestamp = masterTimestampFAdj;
 
-            // prevent any time-travel into the past (this should be impossible, but better be safe)
-            if (masterTimestamp < m_lastMasterTS)
+            // Prevent any time-travel into the past (this should be impossible, but better be safe),
+            // and advance exact duplicates so adjusted timestamps remain strictly increasing.
+            if (masterTimestamp <= m_lastMasterTS)
                 masterTimestamp = m_lastMasterTS + microseconds_t(1);
 
             if (m_strategies.hasFlag(TimeSyncStrategy::WRITE_TSYNCFILE))
@@ -756,8 +757,9 @@ void SecondaryClockSynchronizer::processTimestamp(
                 || (m_strategies.hasFlag(TimeSyncStrategy::SHIFT_TIMESTAMPS_FWD)
                     && m_clockCorrectionOffset.count() < 0))
                 masterTimestamp = secondaryAcqTimestamp - m_expectedOffset - m_clockCorrectionOffset;
-            // prevent any time-travel into the past
-            if (masterTimestamp < m_lastMasterTS)
+            // Prevent any time-travel into the past and advance exact duplicates so adjusted
+            // timestamps remain strictly increasing.
+            if (masterTimestamp <= m_lastMasterTS)
                 masterTimestamp = m_lastMasterTS + microseconds_t(1);
         }
 
@@ -813,17 +815,17 @@ void SecondaryClockSynchronizer::processTimestamp(
     m_clockCorrectionOffset.count());
     */
 
-    // ensure time doesn't run backwards - this really shouldn't happen at this
-    // point, but we prevent this just in case
-    if (masterTimestamp < m_lastMasterTS) {
+    // Ensure time doesn't run backwards - this really shouldn't happen at this
+    // point, but we prevent this just in case. Advance by one microsecond instead
+    // of reusing the previous time so adjusted timestamps remain strictly increasing.
+    if (masterTimestamp <= m_lastMasterTS) {
         SY_LOG_WARNING(
             logTimeSync,
-            "[{}] Timestamp moved backwards when calculating adjusted new time: {} < {} (mitigated by reusing previous "
-            "time)",
+            "[{}] Adjusted timestamp did not advance: {} <= {} (mitigated by advancing 1 us)",
             m_id,
             masterTimestamp.count(),
             m_lastMasterTS.count());
-        masterTimestamp = m_lastMasterTS;
+        masterTimestamp = m_lastMasterTS + microseconds_t(1);
     }
 
     // remember the secondary clock timestamp & master timestamp for the next iteration

--- a/tests/test-timer.cpp
+++ b/tests/test-timer.cpp
@@ -172,10 +172,10 @@ private slots:
             auto syncMasterTS = curMasterTS;
             sync->processTimestamp(syncMasterTS, curSecondaryTS);
 
-            // timestamps must never go backwards
+            // adjusted timestamps must remain strictly increasing
             QVERIFY2(
-                syncMasterTS.count() >= lastMasterTS.count(),
-                qPrintable(QString::number(syncMasterTS.count()) + " >= " + QString::number(lastMasterTS.count())));
+                syncMasterTS.count() > lastMasterTS.count(),
+                qPrintable(QString::number(syncMasterTS.count()) + " > " + QString::number(lastMasterTS.count())));
             lastMasterTS = syncMasterTS;
 
             if (adjustmentIterN > 0) {
@@ -234,10 +234,10 @@ private slots:
             auto syncMasterTS = curMasterTS;
             sync->processTimestamp(syncMasterTS, curSecondaryTS);
 
-            // timestamps must never go backwards
+            // adjusted timestamps must remain strictly increasing
             QVERIFY2(
-                syncMasterTS.count() >= lastMasterTS.count(),
-                qPrintable(QString::number(syncMasterTS.count()) + " >= " + QString::number(lastMasterTS.count())));
+                syncMasterTS.count() > lastMasterTS.count(),
+                qPrintable(QString::number(syncMasterTS.count()) + " > " + QString::number(lastMasterTS.count())));
             lastMasterTS = syncMasterTS;
 
             // sanity checks
@@ -281,10 +281,10 @@ private slots:
 
             sync->processTimestamp(syncMasterTS, curSecondaryTS);
 
-            // timestamps must never go backwards
+            // adjusted timestamps must remain strictly increasing
             QVERIFY2(
-                syncMasterTS.count() >= lastMasterTS.count(),
-                qPrintable(QString::number(syncMasterTS.count()) + " >= " + QString::number(lastMasterTS.count())));
+                syncMasterTS.count() > lastMasterTS.count(),
+                qPrintable(QString::number(syncMasterTS.count()) + " > " + QString::number(lastMasterTS.count())));
             lastMasterTS = syncMasterTS;
 
             if (expectFlukeDivergence) {
@@ -320,10 +320,10 @@ private slots:
             auto syncMasterTS = curMasterTS;
             sync->processTimestamp(syncMasterTS, curSecondaryTS);
 
-            // timestamps must never go backwards
+            // adjusted timestamps must remain strictly increasing
             QVERIFY2(
-                syncMasterTS.count() >= lastMasterTS.count(),
-                qPrintable(QString::number(syncMasterTS.count()) + " >= " + QString::number(lastMasterTS.count())));
+                syncMasterTS.count() > lastMasterTS.count(),
+                qPrintable(QString::number(syncMasterTS.count()) + " > " + QString::number(lastMasterTS.count())));
             lastMasterTS = syncMasterTS;
 
             if (adjustmentIterN > 0) {


### PR DESCRIPTION
This is for the very unlikely edge case that the synchronizer would timestamp two consecutive frames with the same timestamp.